### PR TITLE
Assertion only documents

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -279,7 +279,7 @@ var nullBytes = []byte("null")
 func (id *ObjectId) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && (data[0] == '{' || data[0] == 'O') {
 		var v struct {
-			Id json.RawMessage `json:"$oid"`
+			Id   json.RawMessage `json:"$oid"`
 			Func struct {
 				Id json.RawMessage
 			} `json:"$oidFunc"`

--- a/bson/decimal_test.go
+++ b/bson/decimal_test.go
@@ -1,4 +1,4 @@
-﻿// BSON library for Go
+// BSON library for Go
 //
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
 //

--- a/bson/json.go
+++ b/bson/json.go
@@ -317,7 +317,7 @@ func jencNumberLong(v interface{}) ([]byte, error) {
 func jencInt(v interface{}) ([]byte, error) {
 	n := v.(int)
 	f := `{"$numberLong":"%d"}`
-	if n <= 1<<53 {
+	if int64(n) <= 1<<53 {
 		f = `%d`
 	}
 	return fbytes(f, n), nil

--- a/cluster.go
+++ b/cluster.go
@@ -646,6 +646,10 @@ func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout 
 				cluster.syncServers()
 				time.Sleep(100 * time.Millisecond)
 				continue
+			} else {
+				server.Lock()
+				server.abended = false
+				server.Unlock()
 			}
 		}
 		return s, nil

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1477,7 +1477,6 @@ func (s *S) TestSecondaryModeWithMongosInsert(c *C) {
 	c.Assert(result.A, Equals, 1)
 }
 
-
 func (s *S) TestRemovalOfClusterMember(c *C) {
 	if *fast {
 		c.Skip("-fast")

--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -115,7 +115,12 @@ func (dbs *DBServer) Stop() {
 		select {
 		case <-dbs.tomb.Dead():
 		case <-time.After(5 * time.Second):
-			panic("timeout waiting for mongod process to die")
+			dbs.server.Process.Signal(os.Kill)
+			select {
+			case <-dbs.tomb.Dead():
+			case <-time.After(5 * time.Second):
+				panic("timeout waiting for mongod process to die")
+			}
 		}
 		dbs.server = nil
 	}

--- a/gridfs.go
+++ b/gridfs.go
@@ -657,7 +657,7 @@ func (file *GridFile) insertChunk(data []byte) {
 // an error, if any.
 func (file *GridFile) Seek(offset int64, whence int) (pos int64, err error) {
 	file.m.Lock()
-	debugf("GridFile %p: seeking for %s (whence=%d)", file, offset, whence)
+	debugf("GridFile %p: seeking for %d (whence=%d)", file, offset, whence)
 	defer file.m.Unlock()
 	switch whence {
 	case os.SEEK_SET:

--- a/internal/json/decode.go
+++ b/internal/json/decode.go
@@ -773,7 +773,7 @@ func (d *decodeState) isNull(off int) bool {
 // name consumes a const or function from d.data[d.off-1:], decoding into the value v.
 // the first byte of the function name has been read already.
 func (d *decodeState) name(v reflect.Value) {
-	if d.isNull(d.off-1) {
+	if d.isNull(d.off - 1) {
 		d.literal(v)
 		return
 	}
@@ -1076,9 +1076,9 @@ func (d *decodeState) storeKeyed(v reflect.Value) bool {
 }
 
 var (
-	trueBytes = []byte("true")
+	trueBytes  = []byte("true")
 	falseBytes = []byte("false")
-	nullBytes = []byte("null")
+	nullBytes  = []byte("null")
 )
 
 func (d *decodeState) storeValue(v reflect.Value, from interface{}) {

--- a/internal/json/stream_test.go
+++ b/internal/json/stream_test.go
@@ -131,7 +131,7 @@ func TestDecoder(t *testing.T) {
 		for _, c := range nlines(streamEncoded, i) {
 			// That's stupid isn't it!? nulltrue!?!? :/
 			//if c != '\n' {
-				buf.WriteRune(c)
+			buf.WriteRune(c)
 			//}
 		}
 		out := make([]interface{}, i)

--- a/internal/scram/scram.go
+++ b/internal/scram/scram.go
@@ -133,7 +133,7 @@ func (c *Client) Step(in []byte) bool {
 func (c *Client) step1(in []byte) error {
 	if len(c.clientNonce) == 0 {
 		const nonceLen = 6
-		buf := make([]byte, nonceLen + b64.EncodedLen(nonceLen))
+		buf := make([]byte, nonceLen+b64.EncodedLen(nonceLen))
 		if _, err := rand.Read(buf[:nonceLen]); err != nil {
 			return fmt.Errorf("cannot read random SCRAM-SHA-1 nonce from operating system: %v", err)
 		}

--- a/session.go
+++ b/session.go
@@ -3268,7 +3268,7 @@ func (db *Database) run(socket *mongoSocket, cmd, result interface{}) (err error
 	if result != nil {
 		err = bson.Unmarshal(data, result)
 		if err != nil {
-			debugf("Run command unmarshaling failed: %#v", op, err)
+			debugf("Run command unmarshaling failed: %#v %v", op, err)
 			return err
 		}
 		if globalDebug && globalLogger != nil {

--- a/stats.go
+++ b/stats.go
@@ -30,43 +30,29 @@ import (
 	"sync"
 )
 
-var stats *Stats
-var statsMutex sync.Mutex
+var stats Stats
 
 func SetStats(enabled bool) {
-	statsMutex.Lock()
-	if enabled {
-		if stats == nil {
-			stats = &Stats{}
-		}
-	} else {
-		stats = nil
-	}
-	statsMutex.Unlock()
+	stats.reset(enabled)
 }
 
-func GetStats() (snapshot Stats) {
-	statsMutex.Lock()
-	snapshot = *stats
-	statsMutex.Unlock()
-	return
+func GetStats() Stats {
+	stats.mu.RLock()
+	defer stats.mu.RUnlock()
+	return stats
 }
 
 func ResetStats() {
-	statsMutex.Lock()
+	// If we call ResetStats we assume you want to use stats, so we enable
+	// them.
 	debug("Resetting stats")
-	old := stats
-	stats = &Stats{}
-	// These are absolute values:
-	stats.Clusters = old.Clusters
-	stats.SocketsInUse = old.SocketsInUse
-	stats.SocketsAlive = old.SocketsAlive
-	stats.SocketRefs = old.SocketRefs
-	statsMutex.Unlock()
-	return
+	stats.reset(true)
 }
 
 type Stats struct {
+	mu      sync.RWMutex
+	enabled bool
+
 	Clusters     int
 	MasterConns  int
 	SlaveConns   int
@@ -78,70 +64,74 @@ type Stats struct {
 	SocketRefs   int
 }
 
-func (stats *Stats) cluster(delta int) {
-	if stats != nil {
-		statsMutex.Lock()
-		stats.Clusters += delta
-		statsMutex.Unlock()
+func (stats *Stats) reset(enabled bool) {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+
+	stats.MasterConns = 0
+	stats.SlaveConns = 0
+	stats.SentOps = 0
+	stats.ReceivedOps = 0
+	stats.ReceivedDocs = 0
+
+	if !enabled {
+		// These are absolute values so we don't reset them unless we are
+		// disabling stats altogether.
+		stats.Clusters = 0
+		stats.SocketsInUse = 0
+		stats.SocketsAlive = 0
+		stats.SocketRefs = 0
 	}
+}
+
+func (stats *Stats) cluster(delta int) {
+	stats.mu.Lock()
+	stats.Clusters += delta
+	stats.mu.Unlock()
 }
 
 func (stats *Stats) conn(delta int, master bool) {
-	if stats != nil {
-		statsMutex.Lock()
-		if master {
-			stats.MasterConns += delta
-		} else {
-			stats.SlaveConns += delta
-		}
-		statsMutex.Unlock()
+	stats.mu.Lock()
+	if master {
+		stats.MasterConns += delta
+	} else {
+		stats.SlaveConns += delta
 	}
+	stats.mu.Unlock()
 }
 
 func (stats *Stats) sentOps(delta int) {
-	if stats != nil {
-		statsMutex.Lock()
-		stats.SentOps += delta
-		statsMutex.Unlock()
-	}
+	stats.mu.Lock()
+	stats.SentOps += delta
+	stats.mu.Unlock()
 }
 
 func (stats *Stats) receivedOps(delta int) {
-	if stats != nil {
-		statsMutex.Lock()
-		stats.ReceivedOps += delta
-		statsMutex.Unlock()
-	}
+	stats.mu.Lock()
+	stats.ReceivedOps += delta
+	stats.mu.Unlock()
 }
 
 func (stats *Stats) receivedDocs(delta int) {
-	if stats != nil {
-		statsMutex.Lock()
-		stats.ReceivedDocs += delta
-		statsMutex.Unlock()
-	}
+	stats.mu.Lock()
+	stats.ReceivedDocs += delta
+	stats.mu.Unlock()
 }
 
 func (stats *Stats) socketsInUse(delta int) {
-	if stats != nil {
-		statsMutex.Lock()
-		stats.SocketsInUse += delta
-		statsMutex.Unlock()
-	}
+	stats.mu.Lock()
+	stats.SocketsInUse += delta
+	stats.mu.Unlock()
 }
 
 func (stats *Stats) socketsAlive(delta int) {
-	if stats != nil {
-		statsMutex.Lock()
-		stats.SocketsAlive += delta
-		statsMutex.Unlock()
-	}
+	stats.mu.Lock()
+	stats.SocketsAlive += delta
+	stats.mu.Unlock()
 }
 
 func (stats *Stats) socketRefs(delta int) {
-	if stats != nil {
-		statsMutex.Lock()
-		stats.SocketRefs += delta
-		statsMutex.Unlock()
-	}
+	stats.mu.Lock()
+	stats.SocketRefs += delta
+	stats.mu.Unlock()
 }

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -691,7 +691,7 @@ func (f *flusher) checkpoint(t *transaction, revnos []int64) error {
 		f.debugf("Ready to apply %s. Saving revnos %v: LOST RACE", t, debugRevnos)
 		return f.reload(t)
 	}
-	return nil
+	return err
 }
 
 func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) error {

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -12,7 +12,7 @@ func flush(r *Runner, t *transaction) error {
 		Runner:   r,
 		goal:     t,
 		goalKeys: make(map[docKey]bool),
-		queue:    make(map[docKey][]token),
+		queue:    make(map[docKey][]tokenAndId),
 		debugId:  debugPrefix(),
 	}
 	for _, dkey := range f.goal.docKeys() {
@@ -25,8 +25,34 @@ type flusher struct {
 	*Runner
 	goal     *transaction
 	goalKeys map[docKey]bool
-	queue    map[docKey][]token
+	queue    map[docKey][]tokenAndId
 	debugId  string
+}
+
+type tokenAndId struct {
+	tt  token
+	bid bson.ObjectId
+}
+
+func (ti tokenAndId) id() bson.ObjectId {
+	return ti.bid
+}
+
+func (ti tokenAndId) nonce() string {
+	return ti.tt.nonce()
+}
+
+func (ti tokenAndId) String() string {
+	return string(ti.tt)
+}
+
+func tokensWithIds(q []token) []tokenAndId {
+	out := make([]tokenAndId, len(q))
+	for i, tt := range q {
+		out[i].tt = tt
+		out[i].bid = tt.id()
+	}
+	return out
 }
 
 func (f *flusher) run() (err error) {
@@ -262,7 +288,7 @@ NextDoc:
 			if info.Remove == "" {
 				// Fast path, unless workload is insert/remove heavy.
 				revno[dkey] = info.Revno
-				f.queue[dkey] = info.Queue
+				f.queue[dkey] = tokensWithIds(info.Queue)
 				f.debugf("[A] Prepared document %v with revno %d and queue: %v", dkey, info.Revno, info.Queue)
 				continue NextDoc
 			} else {
@@ -324,7 +350,7 @@ NextDoc:
 					f.debugf("[B] Prepared document %v with revno %d and queue: %v", dkey, info.Revno, info.Queue)
 				}
 				revno[dkey] = info.Revno
-				f.queue[dkey] = info.Queue
+				f.queue[dkey] = tokensWithIds(info.Queue)
 				continue NextDoc
 			}
 		}
@@ -466,7 +492,7 @@ func (f *flusher) rescan(t *transaction, force bool) (revnos []int64, err error)
 				break
 			}
 		}
-		f.queue[dkey] = info.Queue
+		f.queue[dkey] = tokensWithIds(info.Queue)
 		if !found {
 			// Rescanned transaction id was not in the queue. This could mean one
 			// of three things:
@@ -530,12 +556,13 @@ func assembledRevnos(ops []Op, revno map[docKey]int64) []int64 {
 
 func (f *flusher) hasPreReqs(tt token, dkeys docKeys) (prereqs, found bool) {
 	found = true
+	ttId := tt.id()
 NextDoc:
 	for _, dkey := range dkeys {
 		for _, dtt := range f.queue[dkey] {
-			if dtt == tt {
+			if dtt.tt == tt {
 				continue NextDoc
-			} else if dtt.id() != tt.id() {
+			} else if dtt.id() != ttId {
 				prereqs = true
 			}
 		}
@@ -923,17 +950,17 @@ func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) err
 	return nil
 }
 
-func tokensToPull(dqueue []token, pull map[bson.ObjectId]*transaction, dontPull token) []token {
+func tokensToPull(dqueue []tokenAndId, pull map[bson.ObjectId]*transaction, dontPull token) []token {
 	var result []token
 	for j := len(dqueue) - 1; j >= 0; j-- {
 		dtt := dqueue[j]
-		if dtt == dontPull {
+		if dtt.tt == dontPull {
 			continue
 		}
 		if _, ok := pull[dtt.id()]; ok {
 			// It was handled before and this is a leftover invalid
 			// nonce in the queue. Cherry-pick it out.
-			result = append(result, dtt)
+			result = append(result, dtt.tt)
 		}
 	}
 	return result

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -895,6 +895,10 @@ func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) err
 			}
 		case op.Assert != nil:
 			// Pure assertion. No changes to apply.
+			if f.opts.AssertionCleanupLength > 0 && len(pullAll) >= f.opts.AssertionCleanupLength {
+				chaos("")
+				err = c.Update(qdoc, bson.D{{"$pullAll", bson.D{{"txn-queue", pullAll}}}})
+			}
 		}
 		if err == nil {
 			outcome = "DONE"

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -591,7 +591,7 @@ func (f *flusher) assert(t *transaction, revnos []int64, pull map[bson.ObjectId]
 			continue
 		}
 		if op.Insert != nil {
-			return fmt.Errorf("Insert can only Assert txn.DocMissing", op.Assert)
+			return fmt.Errorf("Insert can only Assert txn.DocMissing not %v", op.Assert)
 		}
 		// if revnos[i] < 0 { abort }?
 

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -274,7 +274,7 @@ NextDoc:
 				// txn-queue is too long, abort this transaction. abortOrReload will pull the tokens from
 				// all of the docs that we've touched so far.
 				revno[dkey] = info.Revno
-				f.queue[dkey] = info.Queue
+				f.queue[dkey] = tokensWithIds(info.Queue)
 				revnos := assembledRevnos(t.Ops, revno)
 				pull := map[bson.ObjectId]*transaction{t.Id: t}
 				err := f.abortOrReload(t, revnos, pull)

--- a/txn/sim_test.go
+++ b/txn/sim_test.go
@@ -2,11 +2,11 @@ package txn_test
 
 import (
 	"flag"
+	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/dbtest"
 	"gopkg.in/mgo.v2/txn"
-	. "gopkg.in/check.v1"
 	"math/rand"
 	"time"
 )

--- a/txn/tarjan_test.go
+++ b/txn/tarjan_test.go
@@ -2,8 +2,8 @@ package txn
 
 import (
 	"fmt"
-	"gopkg.in/mgo.v2/bson"
 	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type TarjanSuite struct{}

--- a/txn/txn.go
+++ b/txn/txn.go
@@ -223,6 +223,7 @@ type Runner struct {
 }
 
 const defaultMaxTxnQueueLength = 1000
+const defaultAssertionCleanupLength = 10
 
 // NewRunner returns a new transaction runner that uses tc to hold its
 // transactions.
@@ -252,6 +253,11 @@ type RunnerOptions struct {
 	// Normal operations are likely to only ever hit 10 or so, we use a default
 	// maximum length of 1000.
 	MaxTxnQueueLength int
+
+	// AssertionCleanupLength is the length of a txn-queue that we will start
+	// cleaning up even if this is only an assertion against the document (not
+	// otherwise modifying the document).
+	AssertionCleanupLength int
 }
 
 // SetOptions allows people to change some of the internal behavior of a Runner.
@@ -263,7 +269,8 @@ func (r *Runner) SetOptions(opts RunnerOptions) {
 // Users can use the DefaultRunnerOptions to only override specific behavior.
 func DefaultRunnerOptions() RunnerOptions {
 	return RunnerOptions{
-		MaxTxnQueueLength: defaultMaxTxnQueueLength,
+		MaxTxnQueueLength:      defaultMaxTxnQueueLength,
+		AssertionCleanupLength: defaultAssertionCleanupLength,
 	}
 }
 

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -621,6 +621,162 @@ func (s *S) TestTxnQueueStashStressTest(c *C) {
 	}
 }
 
+func (s *S) checkTxnQueueLength(c *C, expectedQueueLength int) {
+	txn.SetDebug(false)
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	defer txn.SetChaos(txn.Chaos{})
+	err := s.accounts.Insert(M{"_id": 0, "balance": 100})
+	c.Assert(err, IsNil)
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$inc": M{"balance": 100}},
+	}}
+	for i := 0; i < expectedQueueLength; i++ {
+		err := s.runner.Run(ops, "", nil)
+		c.Assert(err, Equals, txn.ErrChaos)
+	}
+	txn.SetDebug(true)
+	// Now that we've filled up the queue, we should see that there are 1000
+	// items in the queue, and the error applying a new one will change.
+	var doc bson.M
+	err = s.accounts.FindId(0).One(&doc)
+	c.Assert(err, IsNil)
+	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedQueueLength)
+	err = s.runner.Run(ops, "", nil)
+	c.Check(err, ErrorMatches, `txn-queue for 0 in "accounts" has too many transactions \(\d+\)`)
+	// The txn-queue should not have grown
+	err = s.accounts.FindId(0).One(&doc)
+	c.Assert(err, IsNil)
+	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedQueueLength)
+}
+
+func (s *S) TestTxnQueueDefaultMaxSize(c *C) {
+	s.runner.SetOptions(txn.DefaultRunnerOptions())
+	s.checkTxnQueueLength(c, 1000)
+}
+
+func (s *S) TestTxnQueueCustomMaxSize(c *C) {
+	opts := txn.DefaultRunnerOptions()
+	opts.MaxTxnQueueLength = 100
+	s.runner.SetOptions(opts)
+	s.checkTxnQueueLength(c, 100)
+}
+
+func (s *S) TestTxnQueueMultipleDocs(c *C) {
+	expectedLength := 100
+	maxDocs := 110
+	opts := txn.DefaultRunnerOptions()
+	opts.MaxTxnQueueLength = expectedLength
+	s.runner.SetOptions(opts)
+	txn.SetDebug(false)
+	createOps := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Insert: M{"balance": 1000},
+	}}
+	for i := 1; i < maxDocs; i++ {
+		createOps = append(createOps, txn.Op{
+			C:      "accounts",
+			Id:     i,
+			Insert: M{"balance": 0},
+		})
+	}
+	err := s.runner.Run(createOps, "", nil)
+	c.Assert(err, IsNil)
+	// Force a bad transaction into the queue
+	badTxnId := "deadbeef1234567812345678_12345678"
+	err = s.accounts.UpdateId(0, M{"$set": M{"txn-queue": []string{badTxnId}}})
+	c.Assert(err, IsNil)
+	for i := 1; i < expectedLength; i++ {
+		ops := []txn.Op{{
+			C:      "accounts",
+			Id:     0,
+			Update: M{"$inc": M{"balance": -1}},
+		}, {
+			C:      "accounts",
+			Id:     i,
+			Update: M{"$inc": M{"balance": 1}},
+		}}
+		err = s.runner.Run(ops, "", nil)
+		c.Assert(err, NotNil)
+		c.Assert(err, ErrorMatches, `cannot find transaction ObjectIdHex."deadbeef1234567812345678".`)
+	}
+	// Now that we've filled up the txn-queue of the first document, any
+	// further changes should be aborted
+	var doc bson.M
+	err = s.accounts.FindId(0).One(&doc)
+	c.Assert(err, IsNil)
+	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedLength)
+	txn.SetDebug(true)
+	for i := 100; i < maxDocs; i++ {
+		ops := []txn.Op{{
+			C:      "accounts",
+			Id:     0,
+			Update: M{"$inc": M{"balance": -1}},
+		}, {
+			C:      "accounts",
+			Id:     i,
+			Update: M{"$inc": M{"balance": 1}},
+		}}
+		err = s.runner.Run(ops, "", nil)
+		c.Assert(err, NotNil)
+		c.Check(err, ErrorMatches, `txn-queue for 0 in "accounts" has too many transactions \(\d+\)`)
+	}
+	err = s.accounts.FindId(0).One(&doc)
+	c.Assert(err, IsNil)
+	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedLength)
+	err = s.accounts.UpdateId(0, M{"$pullAll": M{"txn-queue": []string{badTxnId}}})
+	c.Assert(err, IsNil)
+	c.Log("Updated removing the invalid transaction")
+	// Now we should be able to cleanup
+	err = s.runner.ResumeAll()
+	c.Assert(err, IsNil)
+	c.Log("resumed all")
+}
+
+func (s *S) TestTxnQueueUnlimited(c *C) {
+	opts := txn.DefaultRunnerOptions()
+	// A value of 0 should mean 'unlimited'
+	opts.MaxTxnQueueLength = 0
+	s.runner.SetOptions(opts)
+	// it isn't possible to actually prove 'unlimited' but we can prove that
+	// we at least can insert more than the default number of transactions
+	// without getting a 'too many transactions' failure.
+	txn.SetDebug(false)
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		// Use set-prepared because we are adding more transactions than
+		// other tests, and this speeds up setup time a bit
+		Breakpoint: "set-prepared",
+	})
+	defer txn.SetChaos(txn.Chaos{})
+	err := s.accounts.Insert(M{"_id": 0, "balance": 100})
+	c.Assert(err, IsNil)
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$inc": M{"balance": 100}},
+	}}
+	for i := 0; i < 1100; i++ {
+		err := s.runner.Run(ops, "", nil)
+		c.Assert(err, Equals, txn.ErrChaos)
+	}
+	txn.SetDebug(true)
+	var doc bson.M
+	err = s.accounts.FindId(0).One(&doc)
+	c.Assert(err, IsNil)
+	c.Check(len(doc["txn-queue"].([]interface{})), Equals, 1100)
+	err = s.runner.Run(ops, "", nil)
+	c.Check(err, Equals, txn.ErrChaos)
+	err = s.accounts.FindId(0).One(&doc)
+	c.Assert(err, IsNil)
+	c.Check(len(doc["txn-queue"].([]interface{})), Equals, 1101)
+}
+
 func (s *S) TestPurgeMissingPipelineSizeLimit(c *C) {
 	// This test ensures that PurgeMissing can handle very large
 	// txn-queue fields. Previous iterations of PurgeMissing would

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -861,7 +861,6 @@ func (s *S) TestPurgeMissingPipelineSizeLimit(c *C) {
 var flaky = flag.Bool("flaky", false, "Include flaky tests")
 var txnQueueLength = flag.Int("qlength", 100, "txn-queue length for tests")
 
-
 func (s *S) TestTxnQueueStressTest(c *C) {
 	// This fails about 20% of the time on Mongo 3.2 (I haven't tried
 	// other versions) with account balance being 3999 instead of
@@ -1047,4 +1046,3 @@ func (s *S) TestTxnQueuePreparing(c *C) {
 	}
 	c.Check(len(qdoc.Queue), Equals, expectedCount)
 }
-

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -859,6 +859,8 @@ func (s *S) TestPurgeMissingPipelineSizeLimit(c *C) {
 }
 
 var flaky = flag.Bool("flaky", false, "Include flaky tests")
+var txnQueueLength = flag.Int("qlength", 100, "txn-queue length for tests")
+
 
 func (s *S) TestTxnQueueStressTest(c *C) {
 	// This fails about 20% of the time on Mongo 3.2 (I haven't tried
@@ -932,3 +934,117 @@ func (s *S) TestTxnQueueStressTest(c *C) {
 		}
 	}
 }
+
+type txnQueue struct {
+	Queue []string `bson:"txn-queue"`
+}
+
+func (s *S) TestTxnQueueAssertionGrowth(c *C) {
+	txn.SetDebug(false) // too much spam
+	err := s.accounts.Insert(M{"_id": 0, "balance": 0})
+	c.Assert(err, IsNil)
+	// Create many assertion only transactions.
+	t := time.Now()
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Assert: M{"balance": 0},
+	}}
+	for n := 0; n < *txnQueueLength; n++ {
+		err = s.runner.Run(ops, "", nil)
+		c.Assert(err, IsNil)
+	}
+	var qdoc txnQueue
+	err = s.accounts.FindId(0).One(&qdoc)
+	c.Assert(err, IsNil)
+	c.Check(len(qdoc.Queue), Equals, *txnQueueLength)
+	c.Logf("%8.3fs to set up %d assertions", time.Since(t).Seconds(), *txnQueueLength)
+	t = time.Now()
+	txn.SetChaos(txn.Chaos{})
+	ops = []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$inc": M{"balance": 100}},
+	}}
+	err = s.runner.Run(ops, "", nil)
+	c.Logf("%8.3fs to clear N=%d assertions and add one more txn",
+		time.Since(t).Seconds(), *txnQueueLength)
+	err = s.accounts.FindId(0).One(&qdoc)
+	c.Assert(err, IsNil)
+	c.Check(len(qdoc.Queue), Equals, 1)
+}
+
+func (s *S) TestTxnQueueBrokenPrepared(c *C) {
+	txn.SetDebug(false) // too much spam
+	badTxnToken := "123456789012345678901234_deadbeef"
+	err := s.accounts.Insert(M{"_id": 0, "balance": 0, "txn-queue": []string{badTxnToken}})
+	c.Assert(err, IsNil)
+	t := time.Now()
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$set": M{"balance": 0}},
+	}}
+	errString := `cannot find transaction ObjectIdHex("123456789012345678901234")`
+	for n := 0; n < *txnQueueLength; n++ {
+		err = s.runner.Run(ops, "", nil)
+		c.Assert(err.Error(), Equals, errString)
+	}
+	var qdoc txnQueue
+	err = s.accounts.FindId(0).One(&qdoc)
+	c.Assert(err, IsNil)
+	c.Check(len(qdoc.Queue), Equals, *txnQueueLength+1)
+	c.Logf("%8.3fs to set up %d 'prepared' txns", time.Since(t).Seconds(), *txnQueueLength)
+	t = time.Now()
+	s.accounts.UpdateId(0, bson.M{"$pullAll": bson.M{"txn-queue": []string{badTxnToken}}})
+	ops = []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$inc": M{"balance": 100}},
+	}}
+	err = s.runner.ResumeAll()
+	c.Assert(err, IsNil)
+	c.Logf("%8.3fs to ResumeAll N=%d 'prepared' txns",
+		time.Since(t).Seconds(), *txnQueueLength)
+	err = s.accounts.FindId(0).One(&qdoc)
+	c.Assert(err, IsNil)
+	c.Check(len(qdoc.Queue), Equals, 1)
+}
+
+func (s *S) TestTxnQueuePreparing(c *C) {
+	txn.SetDebug(false) // too much spam
+	err := s.accounts.Insert(M{"_id": 0, "balance": 0, "txn-queue": []string{}})
+	c.Assert(err, IsNil)
+	t := time.Now()
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1.0,
+		Breakpoint: "set-prepared",
+	})
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$set": M{"balance": 0}},
+	}}
+	for n := 0; n < *txnQueueLength; n++ {
+		err = s.runner.Run(ops, "", nil)
+		c.Assert(err, Equals, txn.ErrChaos)
+	}
+	var qdoc txnQueue
+	err = s.accounts.FindId(0).One(&qdoc)
+	c.Assert(err, IsNil)
+	c.Check(len(qdoc.Queue), Equals, *txnQueueLength)
+	c.Logf("%8.3fs to set up %d 'preparing' txns", time.Since(t).Seconds(), *txnQueueLength)
+	txn.SetChaos(txn.Chaos{})
+	t = time.Now()
+	err = s.runner.ResumeAll()
+	c.Logf("%8.3fs to ResumeAll N=%d 'preparing' txns",
+		time.Since(t).Seconds(), *txnQueueLength)
+	err = s.accounts.FindId(0).One(&qdoc)
+	c.Assert(err, IsNil)
+	expectedCount := 100
+	if *txnQueueLength <= expectedCount {
+		expectedCount = *txnQueueLength - 1
+	}
+	c.Check(len(qdoc.Queue), Equals, expectedCount)
+}
+


### PR DESCRIPTION
Cleanup txn-queues even for only Asserted documents.

This has a threshold of how many transactions are ready to be removed
from the transaction queue. Once we reach that threshold, we go ahead
and update the document, even though it wouldn't require updates
otherwise.
In performance testing, it can be seen that having a document whose
queue grows too long can significantly impact how long it takes to apply
a new transaction. (We have to load the information about all the other
transactions that asserted against this document, and check if any of
them need to be applied.)

As an example, looping over 600 transactions to be applied, and timing
how long it takes to apply them with various AssertionCleanupLength
gives:

  1 1.18s
  2 1.17s
  5 1.28s
 10 1.39s
 20 1.81s
 50 2.94s
100 4.81s
  0 22.99s # unlimited

So keeping the queues small significantly impacts transaction speed.
