### PR TITLE
Remove and Insert filter the txn-queue

### DIFF
--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -1036,6 +1036,11 @@ type txnQueue struct {
 
 func (s *S) TestTxnQueueAssertionGrowth(c *C) {
 	txn.SetDebug(false) // too much spam
+	opts := txn.DefaultRunnerOptions()
+	// Disable automatic cleanup of queue, so that we can see the queue
+	// properly cleared on update.
+	opts.AssertionCleanupLength = 0
+	s.runner.SetOptions(opts)
 	err := s.accounts.Insert(M{"_id": 0, "balance": 0})
 	c.Assert(err, IsNil)
 	// Create many assertion only transactions.


### PR DESCRIPTION
When resolving an Insert or Remove operation, cleanup the txn-queue as we would do during an Update.

This does it in memory instead of via Mongo, because we are doing a `$set` operation, so it was already forcing the exact content of the txn-queue. The added test fails appropriately with "txn-queue too long" if we don't prune during insert and remove, and seems like a reasonable set of operations.

This is an application of https://github.com/globalsign/mgo/pull/301 to the juju/mgo codebase.

It also pulls in 1 test suite fix that I had missed when merging my previous work.