### PR TITLE
Use the globalsign testing harness.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/_harness

--- a/auth_test.go
+++ b/auth_test.go
@@ -42,6 +42,10 @@ import (
 	"gopkg.in/mgo.v2"
 )
 
+// failedAuthRegex covers the various messages that Mongo gives from different versions
+// of mongo when you are asking to run a command that needs authentication.
+const failedAuthRegex = "command.*requires authentication|unauthorized|need to login|not authorized .*"
+
 func (s *S) TestAuthLoginDatabase(c *C) {
 	// Test both with a normal database and with an authenticated shard.
 	for _, addr := range []string{"localhost:40002", "localhost:40203"} {
@@ -51,8 +55,7 @@ func (s *S) TestAuthLoginDatabase(c *C) {
 
 		coll := session.DB("mydb").C("mycoll")
 		err = coll.Insert(M{"n": 1})
-		c.Assert(err, ErrorMatches, "unauthorized|need to login|not authorized .*")
-
+		c.Assert(err, ErrorMatches, failedAuthRegex)
 		admindb := session.DB("admin")
 
 		err = admindb.Login("root", "wrong")
@@ -75,7 +78,7 @@ func (s *S) TestAuthLoginSession(c *C) {
 
 		coll := session.DB("mydb").C("mycoll")
 		err = coll.Insert(M{"n": 1})
-		c.Assert(err, ErrorMatches, "unauthorized|need to login|not authorized .*")
+		c.Assert(err, ErrorMatches, failedAuthRegex)
 
 		cred := mgo.Credential{
 			Username: "root",
@@ -109,7 +112,7 @@ func (s *S) TestAuthLoginLogout(c *C) {
 
 		coll := session.DB("mydb").C("mycoll")
 		err = coll.Insert(M{"n": 1})
-		c.Assert(err, ErrorMatches, "unauthorized|need to login|not authorized .*")
+		c.Assert(err, ErrorMatches, failedAuthRegex)
 
 		// Must have dropped auth from the session too.
 		session = session.Copy()
@@ -117,7 +120,7 @@ func (s *S) TestAuthLoginLogout(c *C) {
 
 		coll = session.DB("mydb").C("mycoll")
 		err = coll.Insert(M{"n": 1})
-		c.Assert(err, ErrorMatches, "unauthorized|need to login|not authorized .*")
+		c.Assert(err, ErrorMatches, failedAuthRegex)
 	}
 }
 
@@ -134,7 +137,7 @@ func (s *S) TestAuthLoginLogoutAll(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 	err = coll.Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|need to login|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	// Must have dropped auth from the session too.
 	session = session.Copy()
@@ -142,7 +145,7 @@ func (s *S) TestAuthLoginLogoutAll(c *C) {
 
 	coll = session.DB("mydb").C("mycoll")
 	err = coll.Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|need to login|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 }
 
 func (s *S) TestAuthUpsertUserErrors(c *C) {
@@ -203,7 +206,7 @@ func (s *S) TestAuthUpsertUser(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 	err = coll.Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	err = mydb.Login("myrwuser", "mypass")
 	c.Assert(err, IsNil)
@@ -236,7 +239,7 @@ func (s *S) TestAuthUpsertUser(c *C) {
 	// the roles for myrwuser are different there.
 	othercoll := myotherdb.C("myothercoll")
 	err = othercoll.Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	// Reading works, though.
 	err = othercoll.Find(nil).One(nil)
@@ -274,7 +277,7 @@ func (s *S) TestAuthUpsertUserOtherDBRoles(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 	err = coll.Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	err = coll.Find(nil).One(nil)
 	c.Assert(err, Equals, mgo.ErrNotFound)
@@ -320,7 +323,7 @@ func (s *S) TestAuthUpsertUserUpdates(c *C) {
 	err = usession.DB("mydb").C("mycoll").Find(nil).One(nil)
 	c.Assert(err, Equals, mgo.ErrNotFound)
 	err = usession.DB("mydb").C("mycoll").Insert(M{"ok": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	// Update the user role.
 	user = &mgo.User{
@@ -362,7 +365,7 @@ func (s *S) TestAuthAddUser(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 	err = coll.Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	err = mydb.Login("mywuser", "mypass")
 	c.Assert(err, IsNil)
@@ -395,7 +398,7 @@ func (s *S) TestAuthAddUserReplaces(c *C) {
 
 	// ReadOnly flag was changed too.
 	err = mydb.C("mycoll").Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 }
 
 func (s *S) TestAuthRemoveUser(c *C) {
@@ -474,7 +477,7 @@ func (s *S) TestAuthLoginSwitchUser(c *C) {
 
 	// Can't write.
 	err = coll.Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	// But can read.
 	result := struct{ N int }{}
@@ -509,7 +512,7 @@ func (s *S) TestAuthLoginChangePassword(c *C) {
 
 	// The second login must be in effect, which means read-only.
 	err = mydb.C("mycoll").Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 }
 
 func (s *S) TestAuthLoginCachingWithSessionRefresh(c *C) {
@@ -576,7 +579,7 @@ func (s *S) TestAuthLoginCachingWithNewSession(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 	err = coll.Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|need to login|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 }
 
 func (s *S) TestAuthLoginCachingAcrossPool(c *C) {
@@ -673,7 +676,7 @@ func (s *S) TestAuthLoginCachingAcrossPoolWithLogout(c *C) {
 	// Can't write, since root has been implicitly logged out
 	// when the collection went into the pool, and not revalidated.
 	err = other.DB("mydb").C("mycoll").Insert(M{"n": 1})
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	// But can read due to the revalidated myuser login.
 	result := struct{ N int }{}
@@ -782,7 +785,7 @@ func (s *S) TestAuthURLWithDatabase(c *C) {
 		err = ucoll.FindId(0).One(nil)
 		c.Assert(err, Equals, mgo.ErrNotFound)
 		err = ucoll.Insert(M{"n": 1})
-		c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+		c.Assert(err, ErrorMatches, failedAuthRegex)
 	}
 }
 
@@ -865,7 +868,7 @@ func (s *S) TestAuthScramSha1Cred(c *C) {
 
 	c.Logf("Connected! Testing the need for authentication...")
 	err = mycoll.Find(nil).One(nil)
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	c.Logf("Authenticating...")
 	err = session.Login(cred)
@@ -988,7 +991,7 @@ func (s *S) TestAuthPlainCred(c *C) {
 
 	c.Logf("Connected! Testing the need for authentication...")
 	err = records.Find(nil).One(nil)
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, failedAuthRegex)
 
 	c.Logf("Authenticating...")
 	err = session.Login(cred)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -2065,6 +2065,11 @@ func (s *S) TestDoNotFallbackToMonotonic(c *C) {
 	if !s.versionAtLeast(3, 0) {
 		c.Skip("command-counting logic depends on 3.0+")
 	}
+	// accessing system.indexes is no longer correct in 3.2.17+ you must
+	// use listIndexes, so the test doesn't apply anymore.
+	if s.versionAtLeast(3, 2, 17) {
+		c.Skip("failing on 3.2.17+")
+	}
 
 	session, err := mgo.Dial("localhost:40012")
 	c.Assert(err, IsNil)

--- a/harness/daemons/.env
+++ b/harness/daemons/.env
@@ -22,10 +22,8 @@ versionAtLeast() {
 
 COMMONDOPTSNOIP="
 	--nohttpinterface
-	--noprealloc
 	--nojournal
 	--smallfiles
-	--nssize=1
 	--oplogSize=1
 	--dbpath ./db
 	"
@@ -37,20 +35,51 @@ COMMONCOPTS="
 	$COMMONDOPTS
 	"
 COMMONSOPTS="
-	--chunkSize 1
 	--bind_ip=127.0.0.1
 	"
 
-if versionAtLeast 3 2; then
-	# 3.2 doesn't like --nojournal on config servers.
-	#COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
-	# Using a hacked version of MongoDB 3.2 for now.
+CFG1OPTS=""
+CFG2OPTS=""
+CFG3OPTS=""
 
-	# Go back to MMAPv1 so it's not super sluggish. :-(
-	COMMONDOPTSNOIP="--storageEngine=mmapv1 $COMMONDOPTSNOIP"
-	COMMONDOPTS="--storageEngine=mmapv1 $COMMONDOPTS"
-	COMMONCOPTS="--storageEngine=mmapv1 $COMMONCOPTS"
+MONGOS1OPTS="--configdb 127.0.0.1:40101"
+MONGOS2OPTS="--configdb 127.0.0.1:40102"
+MONGOS3OPTS="--configdb 127.0.0.1:40103"
+
+
+
+if versionAtLeast 3 2; then
+
+    # 3.2 doesn't like --nojournal on config servers.
+	COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
+
+    if versionAtLeast 3 4; then
+      # http interface is disabled by default, this option does not exist anymore
+      COMMONDOPTSNOIP="$(echo "$COMMONDOPTSNOIP" | sed '/--nohttpinterface/d')"
+      COMMONDOPTS="$(echo "$COMMONDOPTS" | sed '/--nohttpinterface/d')"
+      COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nohttpinterface/d')"
+
+
+		if versionAtLeast 3 6; then
+			#In version 3.6 --nojournal is deprecated for replica set members using WiredTiger
+			COMMONDOPTSNOIP="$(echo "$COMMONDOPTSNOIP" | sed '/--nojournal/d')"
+      COMMONDOPTS="$(echo "$COMMONDOPTS" | sed '/--nojournal/d')"
+      COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
+		fi
+
+      # config server need to be started as replica set
+
+      CFG1OPTS="--replSet conf1"
+      CFG2OPTS="--replSet conf2"
+      CFG3OPTS="--replSet conf3"
+
+      MONGOS1OPTS="--configdb conf1/127.0.0.1:40101"
+      MONGOS2OPTS="--configdb conf2/127.0.0.1:40102"
+      MONGOS3OPTS="--configdb conf3/127.0.0.1:40103" 
+	fi
 fi
+
+
 
 if [ "$TRAVIS" = true ]; then
 	set -x

--- a/harness/daemons/.env
+++ b/harness/daemons/.env
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 set -e
 
@@ -6,37 +7,37 @@ MONGOMAJOR=$(echo $MONGOVERSION | sed 's/\([0-9]\+\)\..*/\1/')
 MONGOMINOR=$(echo $MONGOVERSION | sed 's/[0-9]\+\.\([0-9]\+\)/\1/')
 
 versionAtLeast() {
-	TESTMAJOR="$1"
-	TESTMINOR="$2"
-	if [ "$MONGOMAJOR" -gt "$TESTMAJOR" ]; then
-		return 0
-	fi
-	if [ "$MONGOMAJOR" -lt "$TESTMAJOR" ]; then
-		return 100
-	fi
-	if [ "$MONGOMINOR" -ge "$TESTMINOR" ]; then
-		return 0
-	fi
-	return 100
+    TESTMAJOR="$1"
+    TESTMINOR="$2"
+    if [ "$MONGOMAJOR" -gt "$TESTMAJOR" ]; then
+        return 0
+    fi
+    if [ "$MONGOMAJOR" -lt "$TESTMAJOR" ]; then
+        return 100
+    fi
+    if [ "$MONGOMINOR" -ge "$TESTMINOR" ]; then
+        return 0
+    fi
+    return 100
 }
 
 COMMONDOPTSNOIP="
-	--nohttpinterface
-	--nojournal
-	--smallfiles
-	--oplogSize=1
-	--dbpath ./db
-	"
+    --nohttpinterface
+    --nojournal
+    --smallfiles
+    --oplogSize=1
+    --dbpath ./db
+    "
 COMMONDOPTS="
-	$COMMONDOPTSNOIP
-	--bind_ip=127.0.0.1
-	"
+    $COMMONDOPTSNOIP
+    --bind_ip=127.0.0.1
+    "
 COMMONCOPTS="
-	$COMMONDOPTS
-	"
+    $COMMONDOPTS
+    "
 COMMONSOPTS="
-	--bind_ip=127.0.0.1
-	"
+    --bind_ip=127.0.0.1
+    "
 
 CFG1OPTS=""
 CFG2OPTS=""
@@ -51,7 +52,7 @@ MONGOS3OPTS="--configdb 127.0.0.1:40103"
 if versionAtLeast 3 2; then
 
     # 3.2 doesn't like --nojournal on config servers.
-	COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
+    COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
 
     if versionAtLeast 3 4; then
       # http interface is disabled by default, this option does not exist anymore
@@ -60,12 +61,12 @@ if versionAtLeast 3 2; then
       COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nohttpinterface/d')"
 
 
-		if versionAtLeast 3 6; then
-			#In version 3.6 --nojournal is deprecated for replica set members using WiredTiger
-			COMMONDOPTSNOIP="$(echo "$COMMONDOPTSNOIP" | sed '/--nojournal/d')"
-      COMMONDOPTS="$(echo "$COMMONDOPTS" | sed '/--nojournal/d')"
-      COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
-		fi
+        if versionAtLeast 3 6; then
+            #In version 3.6 --nojournal is deprecated for replica set members using WiredTiger
+            COMMONDOPTSNOIP="$(echo "$COMMONDOPTSNOIP" | sed '/--nojournal/d')"
+            COMMONDOPTS="$(echo "$COMMONDOPTS" | sed '/--nojournal/d')"
+            COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
+        fi
 
       # config server need to be started as replica set
 
@@ -76,11 +77,11 @@ if versionAtLeast 3 2; then
       MONGOS1OPTS="--configdb conf1/127.0.0.1:40101"
       MONGOS2OPTS="--configdb conf2/127.0.0.1:40102"
       MONGOS3OPTS="--configdb conf3/127.0.0.1:40103" 
-	fi
+    fi
 fi
 
 
 
 if [ "$TRAVIS" = true ]; then
-	set -x
+    set -x
 fi

--- a/harness/daemons/cfg1/run
+++ b/harness/daemons/cfg1/run
@@ -4,5 +4,6 @@
 
 exec mongod $COMMONCOPTS \
 	--port 40101 \
-	--configsvr
+	--configsvr \
+	$CFG1OPTS
 

--- a/harness/daemons/cfg2/run
+++ b/harness/daemons/cfg2/run
@@ -4,5 +4,6 @@
 
 exec mongod $COMMONCOPTS \
 	--port 40102 \
-	--configsvr
+	--configsvr \
+	$CFG2OPTS
 

--- a/harness/daemons/cfg3/run
+++ b/harness/daemons/cfg3/run
@@ -5,5 +5,6 @@
 exec mongod $COMMONCOPTS \
 	--port 40103 \
 	--configsvr \
+	$CFG3OPTS \
 	--auth \
 	--keyFile=../../certs/keyfile

--- a/harness/daemons/db2/run
+++ b/harness/daemons/db2/run
@@ -3,6 +3,5 @@
 . ../.env
 
 exec mongod $COMMONDOPTS \
-	--shardsvr \
 	--port 40002 \
 	--auth

--- a/harness/daemons/db3/run
+++ b/harness/daemons/db3/run
@@ -3,7 +3,6 @@
 . ../.env
 
 exec mongod $COMMONDOPTS \
-	--shardsvr \
 	--port 40003 \
 	--auth \
 	--sslMode preferSSL \

--- a/harness/daemons/s1/run
+++ b/harness/daemons/s1/run
@@ -4,4 +4,4 @@
 
 exec mongos $COMMONSOPTS \
 	--port 40201 \
-	--configdb 127.0.0.1:40101
+	$MONGOS1OPTS 

--- a/harness/daemons/s2/run
+++ b/harness/daemons/s2/run
@@ -4,4 +4,4 @@
 
 exec mongos $COMMONSOPTS \
 	--port 40202 \
-	--configdb 127.0.0.1:40102
+	$MONGOS2OPTS 

--- a/harness/daemons/s3/run
+++ b/harness/daemons/s3/run
@@ -4,5 +4,5 @@
 
 exec mongos $COMMONSOPTS \
 	--port 40203 \
-	--configdb 127.0.0.1:40103 \
+	$MONGOS3OPTS \
 	--keyFile=../../certs/keyfile

--- a/harness/mongojs/init.js
+++ b/harness/mongojs/init.js
@@ -2,55 +2,74 @@
 var settings = {};
 
 // We know the master of the first set (pri=1), but not of the second.
-var rs1cfg = {_id: "rs1",
-              members: [{_id: 1, host: "127.0.0.1:40011", priority: 1, tags: {rs1: "a"}},
-                        {_id: 2, host: "127.0.0.1:40012", priority: 0, tags: {rs1: "b"}},
-                        {_id: 3, host: "127.0.0.1:40013", priority: 0, tags: {rs1: "c"}}],
-              settings: settings}
-var rs2cfg = {_id: "rs2",
-              members: [{_id: 1, host: "127.0.0.1:40021", priority: 1, tags: {rs2: "a"}},
-                        {_id: 2, host: "127.0.0.1:40022", priority: 1, tags: {rs2: "b"}},
-                        {_id: 3, host: "127.0.0.1:40023", priority: 1, tags: {rs2: "c"}}],
-              settings: settings}
-var rs3cfg = {_id: "rs3",
-              members: [{_id: 1, host: "127.0.0.1:40031", priority: 1, tags: {rs3: "a"}},
-                        {_id: 2, host: "127.0.0.1:40032", priority: 1, tags: {rs3: "b"}},
-                        {_id: 3, host: "127.0.0.1:40033", priority: 1, tags: {rs3: "c"}}],
-              settings: settings}
+var rs1cfg = {
+    _id: "rs1",
+    members: [{ _id: 1, host: "127.0.0.1:40011", priority: 1, tags: { rs1: "a" } },
+    { _id: 2, host: "127.0.0.1:40012", priority: 0, tags: { rs1: "b" } },
+    { _id: 3, host: "127.0.0.1:40013", priority: 0, tags: { rs1: "c" } }],
+    settings: settings
+}
+var rs2cfg = {
+    _id: "rs2",
+    members: [{ _id: 1, host: "127.0.0.1:40021", priority: 1, tags: { rs2: "a" } },
+    { _id: 2, host: "127.0.0.1:40022", priority: 1, tags: { rs2: "b" } },
+    { _id: 3, host: "127.0.0.1:40023", priority: 1, tags: { rs2: "c" } }],
+    settings: settings
+}
+var rs3cfg = {
+    _id: "rs3",
+    members: [{ _id: 1, host: "127.0.0.1:40031", priority: 1, tags: { rs3: "a" } },
+    { _id: 2, host: "127.0.0.1:40032", priority: 0, tags: { rs3: "b" } },
+    { _id: 3, host: "127.0.0.1:40033", priority: 0, tags: { rs3: "c" } }],
+    settings: settings
+}
 
 for (var i = 0; i != 60; i++) {
-	try {
-		db1 = new Mongo("127.0.0.1:40001").getDB("admin")
-		db2 = new Mongo("127.0.0.1:40002").getDB("admin")
-		rs1a = new Mongo("127.0.0.1:40011").getDB("admin")
-		rs2a = new Mongo("127.0.0.1:40021").getDB("admin")
-		rs3a = new Mongo("127.0.0.1:40031").getDB("admin")
-		break
-	} catch(err) {
-		print("Can't connect yet...")
-	}
-	sleep(1000)
+    try {
+        db1 = new Mongo("127.0.0.1:40001").getDB("admin")
+        rs1a = new Mongo("127.0.0.1:40011").getDB("admin")
+        rs2a = new Mongo("127.0.0.1:40021").getDB("admin")
+        rs3a = new Mongo("127.0.0.1:40031").getDB("admin")
+        cfg1 = new Mongo("127.0.0.1:40101").getDB("admin")
+        cfg2 = new Mongo("127.0.0.1:40102").getDB("admin")
+        cfg3 = new Mongo("127.0.0.1:40103").getDB("admin")
+        break
+    } catch (err) {
+        print("Can't connect yet...")
+    }
+    sleep(1000)
 }
 
 function hasSSL() {
     return Boolean(db1.serverBuildInfo().OpenSSLVersion)
 }
 
-rs1a.runCommand({replSetInitiate: rs1cfg})
-rs2a.runCommand({replSetInitiate: rs2cfg})
-rs3a.runCommand({replSetInitiate: rs3cfg})
-
-function configShards() {
-    cfg1 = new Mongo("127.0.0.1:40201").getDB("admin")
-    cfg1.runCommand({addshard: "127.0.0.1:40001"})
-    cfg1.runCommand({addshard: "rs1/127.0.0.1:40011"})
-
-    cfg2 = new Mongo("127.0.0.1:40202").getDB("admin")
-    cfg2.runCommand({addshard: "rs2/127.0.0.1:40021"})
-
-    cfg3 = new Mongo("127.0.0.1:40203").getDB("admin")
-    cfg3.runCommand({addshard: "rs3/127.0.0.1:40031"})
+function versionAtLeast() {
+    var version = db1.version().split(".")
+    for (var i = 0; i < arguments.length; i++) {
+        if (i == arguments.length) {
+            return false
+        }
+        if (arguments[i] != version[i]) {
+            return version[i] >= arguments[i]
+        }
+    }
+    return true
 }
+
+
+if (versionAtLeast(3, 4)) {
+    print("configuring config server for mongodb 3.4+")
+    cfg1.runCommand({ replSetInitiate: { _id: "conf1", configsvr: true, members: [{ "_id": 1, "host": "localhost:40101" }] } })
+    cfg2.runCommand({ replSetInitiate: { _id: "conf2", configsvr: true, members: [{ "_id": 1, "host": "localhost:40102" }] } })
+    cfg3.runCommand({ replSetInitiate: { _id: "conf3", configsvr: true, members: [{ "_id": 1, "host": "localhost:40103" }] } })
+}
+
+sleep(3000)
+
+rs1a.runCommand({ replSetInitiate: rs1cfg })
+rs2a.runCommand({ replSetInitiate: rs2cfg })
+rs3a.runCommand({ replSetInitiate: rs3cfg })
 
 function configAuth() {
     var addrs = ["127.0.0.1:40002", "127.0.0.1:40203", "127.0.0.1:40031"]
@@ -60,21 +79,26 @@ function configAuth() {
     for (var i in addrs) {
         print("Configuring auth for", addrs[i])
         var db = new Mongo(addrs[i]).getDB("admin")
-        var v = db.serverBuildInfo().versionArray
         var timedOut = false
-        if (v < [2, 5]) {
-            db.addUser("root", "rapadura")
-        } else {
+        createUser:
+        for (var i = 0; i < 60; i++) {
             try {
-                db.createUser({user: "root", pwd: "rapadura", roles: ["root"]})
+                db.createUser({ user: "root", pwd: "rapadura", roles: ["root"] })
             } catch (err) {
                 // 3.2 consistently fails replication of creds on 40031 (config server) 
                 print("createUser command returned an error: " + err)
                 if (String(err).indexOf("timed out") >= 0) {
                     timedOut = true;
                 }
+                // on 3.6 cluster with keyFile, we sometimes get this error 
+                if (String(err).indexOf("Cache Reader No keys found for HMAC that is valid for time")) {
+                    sleep(500)
+                    continue createUser;
+                }
             }
+            break;
         }
+
         for (var i = 0; i < 60; i++) {
             var ok = db.auth("root", "rapadura")
             if (ok || !timedOut) {
@@ -82,18 +106,47 @@ function configAuth() {
             }
             sleep(1000);
         }
-        if (v >= [2, 6]) {
-            db.createUser({user: "reader", pwd: "rapadura", roles: ["readAnyDatabase"]})
-        } else if (v >= [2, 4]) {
-            db.addUser({user: "reader", pwd: "rapadura", roles: ["readAnyDatabase"]})
-        } else {
-            db.addUser("reader", "rapadura", true)
+        sleep(500)
+        db.createUser({ user: "reader", pwd: "rapadura", roles: ["readAnyDatabase"] })
+        sleep(3000)
+    }
+}
+
+function addShard(adminDb, shardList) {
+    for (var index = 0; index < shardList.length; index++) {
+        for (var i = 0; i < 10; i++) {
+            var result = adminDb.runCommand({ addshard: shardList[index] })
+            if (result.ok == 1) {
+                print("shard " + shardList[index] + " sucessfully added")
+                break
+            } else {
+                print("fail to add shard: " + shardList[index] + " error: " + JSON.stringify(result) + ", retrying in 1s")
+                sleep(1000)
+            }
         }
     }
 }
 
+function configShards() {
+    s1 = new Mongo("127.0.0.1:40201").getDB("admin")
+    addShard(s1, ["127.0.0.1:40001", "rs1/127.0.0.1:40011"])
+
+    s2 = new Mongo("127.0.0.1:40202").getDB("admin")
+    addShard(s2, ["rs2/127.0.0.1:40021"])
+
+    s3 = new Mongo("127.0.0.1:40203").getDB("admin")
+    for (var i = 0; i < 10; i++) {
+        var ok = s3.auth("root", "rapadura")
+        if (ok) {
+            break
+        }
+        sleep(1000)
+    }
+    addShard(s3, ["rs3/127.0.0.1:40031"])
+}
+
 function countHealthy(rs) {
-    var status = rs.runCommand({replSetGetStatus: 1})
+    var status = rs.runCommand({ replSetGetStatus: 1 })
     var count = 0
     var primary = 0
     if (typeof status.members != "undefined") {
@@ -108,7 +161,7 @@ function countHealthy(rs) {
         }
     }
     if (primary == 0) {
-	    count = 0
+        count = 0
     }
     return count
 }
@@ -119,8 +172,9 @@ for (var i = 0; i != 60; i++) {
     var count = countHealthy(rs1a) + countHealthy(rs2a) + countHealthy(rs3a)
     print("Replica sets have", count, "healthy nodes.")
     if (count == totalRSMembers) {
-        configShards()
         configAuth()
+        sleep(2000)
+        configShards()
         quit(0)
     }
     sleep(1000)

--- a/harness/setup.sh
+++ b/harness/setup.sh
@@ -30,7 +30,7 @@ start() {
         UP=$(svstat daemons/* | grep ' up ' | grep -v ' [0-3] seconds' | wc -l)
         echo "$UP processes up..."
         if [ x$COUNT = x$UP ]; then
-            echo "Running setup.js with mongo..."
+            echo "Running init.js with mongo..."
             mongo --nodb ../harness/mongojs/init.js
             exit 0
         fi

--- a/session_test.go
+++ b/session_test.go
@@ -301,11 +301,11 @@ func (s *S) TestDatabaseAndCollectionNames(c *C) {
 
 	names, err = db1.CollectionNames()
 	c.Assert(err, IsNil)
-	c.Assert(names, DeepEquals, []string{"col1", "col2", "system.indexes"})
+	c.Assert(filterDBs(names), DeepEquals, []string{"col1", "col2"})
 
 	names, err = db2.CollectionNames()
 	c.Assert(err, IsNil)
-	c.Assert(names, DeepEquals, []string{"col3", "system.indexes"})
+	c.Assert(filterDBs(names), DeepEquals, []string{"col3"})
 }
 
 func (s *S) TestSelect(c *C) {
@@ -734,7 +734,7 @@ func filterDBs(dbs []string) []string {
 	var i int
 	for _, name := range dbs {
 		switch name {
-		case "admin", "local":
+		case "admin", "local", "config", "system.indexes":
 		default:
 			dbs[i] = name
 			i++
@@ -760,14 +760,14 @@ func (s *S) TestDropCollection(c *C) {
 
 	names, err := db.CollectionNames()
 	c.Assert(err, IsNil)
-	c.Assert(names, DeepEquals, []string{"col2", "system.indexes"})
+	c.Assert(filterDBs(names), DeepEquals, []string{"col2"})
 
 	err = db.C("col2").DropCollection()
 	c.Assert(err, IsNil)
 
 	names, err = db.CollectionNames()
 	c.Assert(err, IsNil)
-	c.Assert(names, DeepEquals, []string{"system.indexes"})
+	c.Assert(filterDBs(names), DeepEquals, []string{})
 }
 
 func (s *S) TestCreateCollectionCapped(c *C) {
@@ -797,6 +797,9 @@ func (s *S) TestCreateCollectionCapped(c *C) {
 }
 
 func (s *S) TestCreateCollectionNoIndex(c *C) {
+	if s.versionAtLeast(4, 0) {
+		c.Skip("can't set autoIndexId:false when creating collections in databases other than the local database in 4.0 and above")
+	}
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
 	defer session.Close()
@@ -2854,16 +2857,14 @@ var indexTests = []struct {
 	},
 }, {
 	mgo.Index{
-		Key:      []string{"a", "-b"},
-		Unique:   true,
-		DropDups: true,
+		Key:    []string{"a", "-b"},
+		Unique: true,
 	},
 	M{
-		"name":     "a_1_b_-1",
-		"key":      M{"a": 1, "b": -1},
-		"ns":       "mydb.mycoll",
-		"unique":   true,
-		"dropDups": true,
+		"name":   "a_1_b_-1",
+		"key":    M{"a": 1, "b": -1},
+		"ns":     "mydb.mycoll",
+		"unique": true,
 	},
 }, {
 	mgo.Index{
@@ -2977,19 +2978,37 @@ var indexTests = []struct {
 	},
 }}
 
+// getIndex34 uses the listIndexes command to obtain a list of indexes on
+// collection, and searches through the result looking for an index with name.
+// This can only be used in 3.4+.
+//
+// The default "_id_" index is never returned, and the "v" field is removed from
+// the response.
+func getIndex34(session *mgo.Session, db, collection, name string) M {
+	cmd := bson.M{"listIndexes": collection}
+	result := M{}
+	session.DB(db).Run(cmd, result)
+
+	var obtained = M{}
+	for _, v := range result["cursor"].(M)["firstBatch"].([]interface{}) {
+		index := v.(M)
+		if index["name"] == name {
+			delete(index, "v")
+			obtained = index
+			break
+		}
+	}
+	return obtained
+}
+
 func (s *S) TestEnsureIndex(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
 	defer session.Close()
 
 	coll := session.DB("mydb").C("mycoll")
-	idxs := session.DB("mydb").C("system.indexes")
 
 	for _, test := range indexTests {
-		if !s.versionAtLeast(2, 4) && test.expected["textIndexVersion"] != nil {
-			continue
-		}
-
 		err = coll.EnsureIndex(test.index)
 		msg := "text search not enabled"
 		if err != nil && strings.Contains(err.Error(), msg) {
@@ -3002,22 +3021,26 @@ func (s *S) TestEnsureIndex(c *C) {
 			expectedName, _ = test.expected["name"].(string)
 		}
 
-		obtained := M{}
-		err = idxs.Find(M{"name": expectedName}).One(obtained)
-		c.Assert(err, IsNil)
-
-		delete(obtained, "v")
-
-		if s.versionAtLeast(2, 7) {
-			// Was deprecated in 2.6, and not being reported by 2.7+.
-			delete(test.expected, "dropDups")
-			test.index.DropDups = false
-		}
 		if s.versionAtLeast(3, 2) && test.expected["textIndexVersion"] != nil {
 			test.expected["textIndexVersion"] = 3
 		}
 
-		c.Assert(obtained, DeepEquals, test.expected)
+		// As of 3.4.X, "system.indexes" is no longer available - instead use:
+		//
+		// 		db.runCommand({"listIndexes": <collectionName>})
+		//
+		// and iterate over the returned cursor.
+		if s.versionAtLeast(3, 2, 17) {
+			c.Assert(getIndex34(session, "mydb", "mycoll", test.expected["name"].(string)), DeepEquals, test.expected)
+		} else {
+			idxs := session.DB("mydb").C("system.indexes")
+			obtained := M{}
+			err = idxs.Find(M{"name": expectedName}).One(obtained)
+			c.Assert(err, IsNil)
+
+			delete(obtained, "v")
+			c.Assert(obtained, DeepEquals, test.expected)
+		}
 
 		// The result of Indexes must match closely what was used to create the index.
 		indexes, err := coll.Indexes()
@@ -3047,7 +3070,7 @@ func (s *S) TestEnsureIndex(c *C) {
 		if wantIndex.LanguageOverride == "" {
 			wantIndex.LanguageOverride = gotIndex.LanguageOverride
 		}
-		for name, _ := range gotIndex.Weights {
+		for name := range gotIndex.Weights {
 			if _, ok := wantIndex.Weights[name]; !ok {
 				if wantIndex.Weights == nil {
 					wantIndex.Weights = make(map[string]int)
@@ -3117,34 +3140,53 @@ func (s *S) TestEnsureIndexKey(c *C) {
 	err = coll.EnsureIndexKey("a")
 	c.Assert(err, IsNil)
 
-	err = coll.EnsureIndexKey("a", "-b")
-	c.Assert(err, IsNil)
+	if s.versionAtLeast(3, 2, 17) {
+		expected := M{
+			"name": "a_1",
+			"key":  M{"a": 1},
+			"ns":   "mydb.mycoll",
+		}
+		c.Assert(getIndex34(session, "mydb", "mycoll", "a_1"), DeepEquals, expected)
 
-	sysidx := session.DB("mydb").C("system.indexes")
+		err = coll.EnsureIndexKey("a", "-b")
+		c.Assert(err, IsNil)
 
-	result1 := M{}
-	err = sysidx.Find(M{"name": "a_1"}).One(result1)
-	c.Assert(err, IsNil)
+		expected = M{
+			"name": "a_1_b_-1",
+			"key":  M{"a": 1, "b": -1},
+			"ns":   "mydb.mycoll",
+		}
+		c.Assert(getIndex34(session, "mydb", "mycoll", "a_1_b_-1"), DeepEquals, expected)
+	} else {
+		err = coll.EnsureIndexKey("a", "-b")
+		c.Assert(err, IsNil)
 
-	result2 := M{}
-	err = sysidx.Find(M{"name": "a_1_b_-1"}).One(result2)
-	c.Assert(err, IsNil)
+		sysidx := session.DB("mydb").C("system.indexes")
 
-	delete(result1, "v")
-	expected1 := M{
-		"name": "a_1",
-		"key":  M{"a": 1},
-		"ns":   "mydb.mycoll",
+		result1 := M{}
+		err = sysidx.Find(M{"name": "a_1"}).One(result1)
+		c.Assert(err, IsNil)
+
+		result2 := M{}
+		err = sysidx.Find(M{"name": "a_1_b_-1"}).One(result2)
+		c.Assert(err, IsNil)
+
+		delete(result1, "v")
+		expected1 := M{
+			"name": "a_1",
+			"key":  M{"a": 1},
+			"ns":   "mydb.mycoll",
+		}
+		c.Assert(result1, DeepEquals, expected1)
+
+		delete(result2, "v")
+		expected2 := M{
+			"name": "a_1_b_-1",
+			"key":  M{"a": 1, "b": -1},
+			"ns":   "mydb.mycoll",
+		}
+		c.Assert(result2, DeepEquals, expected2)
 	}
-	c.Assert(result1, DeepEquals, expected1)
-
-	delete(result2, "v")
-	expected2 := M{
-		"name": "a_1_b_-1",
-		"key":  M{"a": 1, "b": -1},
-		"ns":   "mydb.mycoll",
-	}
-	c.Assert(result2, DeepEquals, expected2)
 }
 
 func (s *S) TestEnsureIndexDropIndex(c *C) {
@@ -3163,22 +3205,44 @@ func (s *S) TestEnsureIndexDropIndex(c *C) {
 	err = coll.DropIndex("-b")
 	c.Assert(err, IsNil)
 
-	sysidx := session.DB("mydb").C("system.indexes")
+	if s.versionAtLeast(3, 2, 17) {
+		// system.indexes is deprecated since 3.0, use
+		// db.runCommand({"listIndexes": <collectionName>})
+		// instead
 
-	err = sysidx.Find(M{"name": "a_1"}).One(nil)
-	c.Assert(err, IsNil)
+		// Assert it exists
+		c.Assert(getIndex34(session, "mydb", "mycoll", "a_1"), DeepEquals, M{"key": M{"a": 1}, "name": "a_1", "ns": "mydb.mycoll"})
 
-	err = sysidx.Find(M{"name": "b_1"}).One(nil)
-	c.Assert(err, Equals, mgo.ErrNotFound)
+		// Assert a missing index returns an empty M{}
+		c.Assert(getIndex34(session, "mydb", "mycoll", "b_1"), DeepEquals, M{})
 
-	err = coll.DropIndex("a")
-	c.Assert(err, IsNil)
+		err = coll.DropIndex("a")
+		c.Assert(err, IsNil)
 
-	err = sysidx.Find(M{"name": "a_1"}).One(nil)
-	c.Assert(err, Equals, mgo.ErrNotFound)
+		// Ensure missing
+		c.Assert(getIndex34(session, "mydb", "mycoll", "a_1"), DeepEquals, M{})
 
-	err = coll.DropIndex("a")
-	c.Assert(err, ErrorMatches, "index not found.*")
+		// Try to drop it again
+		err = coll.DropIndex("a")
+		c.Assert(err, ErrorMatches, "index not found.*")
+	} else {
+		sysidx := session.DB("mydb").C("system.indexes")
+
+		err = sysidx.Find(M{"name": "a_1"}).One(nil)
+		c.Assert(err, IsNil)
+
+		err = sysidx.Find(M{"name": "b_1"}).One(nil)
+		c.Assert(err, Equals, mgo.ErrNotFound)
+
+		err = coll.DropIndex("a")
+		c.Assert(err, IsNil)
+
+		err = sysidx.Find(M{"name": "a_1"}).One(nil)
+		c.Assert(err, Equals, mgo.ErrNotFound)
+
+		err = coll.DropIndex("a")
+		c.Assert(err, ErrorMatches, "index not found.*")
+	}
 }
 
 func (s *S) TestEnsureIndexDropIndexName(c *C) {
@@ -3196,23 +3260,44 @@ func (s *S) TestEnsureIndexDropIndexName(c *C) {
 
 	err = coll.DropIndexName("a")
 	c.Assert(err, IsNil)
+	if s.versionAtLeast(3, 2, 17) {
+		// system.indexes is deprecated since 3.0, use
+		// db.runCommand({"listIndexes": <collectionName>})
+		// instead
 
-	sysidx := session.DB("mydb").C("system.indexes")
+		// Assert it exists
+		c.Assert(getIndex34(session, "mydb", "mycoll", "a_1"), DeepEquals, M{"ns": "mydb.mycoll", "key": M{"a": 1}, "name": "a_1"})
 
-	err = sysidx.Find(M{"name": "a_1"}).One(nil)
-	c.Assert(err, IsNil)
+		// Assert M{} is returned for a missing index
+		c.Assert(getIndex34(session, "mydb", "mycoll", "a"), DeepEquals, M{})
 
-	err = sysidx.Find(M{"name": "a"}).One(nil)
-	c.Assert(err, Equals, mgo.ErrNotFound)
+		err = coll.DropIndexName("a_1")
+		c.Assert(err, IsNil)
 
-	err = coll.DropIndexName("a_1")
-	c.Assert(err, IsNil)
+		// Ensure it's gone
+		c.Assert(getIndex34(session, "mydb", "mycoll", "a_1"), DeepEquals, M{})
 
-	err = sysidx.Find(M{"name": "a_1"}).One(nil)
-	c.Assert(err, Equals, mgo.ErrNotFound)
+		err = coll.DropIndexName("a_1")
+		c.Assert(err, ErrorMatches, "index not found.*")
 
-	err = coll.DropIndexName("a_1")
-	c.Assert(err, ErrorMatches, "index not found.*")
+	} else {
+		sysidx := session.DB("mydb").C("system.indexes")
+
+		err = sysidx.Find(M{"name": "a_1"}).One(nil)
+		c.Assert(err, IsNil)
+
+		err = sysidx.Find(M{"name": "a"}).One(nil)
+		c.Assert(err, Equals, mgo.ErrNotFound)
+
+		err = coll.DropIndexName("a_1")
+		c.Assert(err, IsNil)
+
+		err = sysidx.Find(M{"name": "a_1"}).One(nil)
+		c.Assert(err, Equals, mgo.ErrNotFound)
+
+		err = coll.DropIndexName("a_1")
+		c.Assert(err, ErrorMatches, "index not found.*")
+	}
 }
 
 func (s *S) TestEnsureIndexCaching(c *C) {


### PR DESCRIPTION
This should allow supporting more versions of Mongo than the existing
mgo driver. I'm still getting some failures trying to run against Mongo 4.0, but I think this does at least let the harness start up and starts handling a few of the tests.
