### PR TITLE
Make wait.js wait for mongos.

### DIFF
--- a/harness/mongojs/wait.js
+++ b/harness/mongojs/wait.js
@@ -22,6 +22,16 @@ for (var i = 0; i != 60; i++) {
 		rs3a.auth("root", "rapadura")
 		db1 = new Mongo("127.0.0.1:40001").getDB("admin")
 		db2 = new Mongo("127.0.0.1:40002").getDB("admin")
+		s1 = new Mongo("127.0.0.1:40201").getDB("admin")
+		s2 = new Mongo("127.0.0.1:40202").getDB("admin")
+		s3 = new Mongo("127.0.0.1:40203").getDB("admin")
+		for (var i = 0; i < 10; i++) {
+			var ok = s3.auth("root", "rapadura")
+			if (ok) {
+				break
+			}
+			sleep(500)
+		}
 		break
 	} catch(err) {
 		print("Can't connect yet...")
@@ -45,7 +55,7 @@ function countHealthy(rs) {
         }
     }
     if (primary == 0) {
-	    count = 0
+        count = 0
     }
     return count
 }


### PR DESCRIPTION
Some tests were stopping mongos, and then calling StartAll which called
wait.js. But Wait wasn't actually waiting for the mongos to be up and
running. Which would cause the next test to fail.

This fixes a failure that I saw after TestMonotonicSlaveOkFlagWithMongos. (The SetupTest would fail during 'dropall.js' because the mongos wasn't back up yet.)