### PR TITLE
Mgo Server Side TXNs

### DIFF
--- a/sstxn/sstxn.go
+++ b/sstxn/sstxn.go
@@ -1,0 +1,403 @@
+// Copyright 2018 Canonical Ltd.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// The sstxn package implements the txn/Runner interface for server-side transactions.
+package sstxn
+
+import (
+	"fmt"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// Logger defines the types of logging that we will be doing
+type Logger interface {
+	Tracef(message string, args ...interface{})
+	Debugf(message string, args ...interface{})
+	Infof(message string, args ...interface{})
+	Warningf(message string, args ...interface{})
+	Errorf(message string, args ...interface{})
+	Criticalf(message string, args ...interface{})
+}
+
+type nilLogger struct {
+}
+
+func (nilLogger) Tracef(message string, args ...interface{})    {}
+func (nilLogger) Debugf(message string, args ...interface{})    {}
+func (nilLogger) Infof(message string, args ...interface{})     {}
+func (nilLogger) Warningf(message string, args ...interface{})  {}
+func (nilLogger) Errorf(message string, args ...interface{})    {}
+func (nilLogger) Criticalf(message string, args ...interface{}) {}
+
+var _ Logger = nilLogger{}
+
+// A Runner applies operations as part of a transaction onto any number
+// of collections within a database. See the Run method for details.
+type Runner struct {
+	db            *mgo.Database
+	logCollection *mgo.Collection // log
+	logger        Logger
+}
+
+// NewRunner returns a new transaction runner that uses tc to hold its
+// transactions.
+//
+// Multiple transaction collections may exist in a single database, but
+// all collections that are touched by operations in a given transaction
+// collection must be handled exclusively by it.
+//
+// A second collection with the same name of tc but suffixed by ".stash"
+// will be used for implementing the transactional behavior of insert
+// and remove operations.
+func NewRunner(db *mgo.Database, logger Logger) *Runner {
+	if logger == nil {
+		logger = nilLogger{}
+	}
+	return &Runner{
+		db:            db,
+		logCollection: nil,
+		logger:        logger,
+	}
+}
+
+// Run creates a new transaction with ops and runs it immediately.
+// The id parameter specifies the transaction id, and may be written
+// down ahead of time to later verify the success of the change and
+// resume it, when the procedure is interrupted for any reason. If
+// empty, a random id will be generated.
+// The info parameter, if not nil, is included under the "i"
+// field of the transaction document.
+//
+// Operations across documents are not atomically applied, but are
+// guaranteed to be eventually all applied in the order provided or
+// all aborted, as long as the affected documents are only modified
+// through transactions. If documents are simultaneously modified
+// by transactions and out of transactions the behavior is undefined.
+//
+// If Run returns no errors, all operations were applied successfully.
+// If it returns ErrAborted, one or more operations can't be applied
+// and the transaction was entirely aborted with no changes performed.
+//
+// Any number of transactions may be run concurrently, with one
+// runner or many.
+func (r *Runner) Run(ops []txn.Op, id bson.ObjectId) (err error) {
+	const efmt = "error in transaction op %d: %s"
+	for i := range ops {
+		op := &ops[i]
+		if op.C == "" || op.Id == nil {
+			return fmt.Errorf(efmt, i, "C or Id missing")
+		}
+		changes := 0
+		if op.Insert != nil {
+			changes++
+		}
+		if op.Update != nil {
+			changes++
+		}
+		if op.Remove {
+			changes++
+		}
+		if changes > 1 {
+			return fmt.Errorf(efmt, i, "more than one of Insert/Update/Remove set")
+		}
+		if changes == 0 && op.Assert == nil {
+			return fmt.Errorf(efmt, i, "none of Assert/Insert/Update/Remove set")
+		}
+	}
+	if id == "" {
+		id = bson.NewObjectId()
+	}
+	completed := false
+	if err := r.db.Session.StartTransaction(); err != nil {
+		return err
+	}
+	defer func() {
+		if !completed {
+			err := r.db.Session.AbortTransaction()
+			if err != nil {
+				r.logger.Errorf("error while aborting: %v", err)
+			}
+		}
+	}()
+	if err := r.checkAsserts(ops); err != nil {
+		return err
+	}
+	if err := r.applyOps(ops); err != nil {
+		return err
+	}
+	if err := r.updateLog(ops, id); err != nil {
+		return err
+	}
+	if err := r.db.Session.CommitTransaction(); err != nil {
+		return err
+	}
+	completed = true
+	return nil
+}
+
+var idFields = bson.D{{Name: "_id", Value: 1}}
+var revnoFields = bson.D{{Name: "txn-revno", Value: 1}}
+
+type revnoDoc struct {
+	Revno int64 `bson:"txn-revno,omitempty"`
+}
+
+func (r *Runner) checkAsserts(ops []txn.Op) error {
+	for _, op := range ops {
+		if op.Assert == nil {
+			continue
+		}
+		if op.Insert != nil && op.Assert != txn.DocMissing {
+			if op.Assert == txn.DocExists {
+				return fmt.Errorf("Insert can only Assert txn.DocMissing not txn.DocExists")
+			} else {
+				return fmt.Errorf("Insert can only Assert txn.DocMissing not %v", op.Assert)
+			}
+		}
+
+		c := r.db.C(op.C)
+		if op.Assert == txn.DocExists {
+			if c.FindId(op.Id).Select(idFields).One(nil) == mgo.ErrNotFound {
+				r.logger.Tracef("DocExists assertion failed for op: %#v", op)
+				return txn.ErrAborted
+			}
+		} else if op.Assert == txn.DocMissing {
+			if c.FindId(op.Id).Select(idFields).One(nil) != mgo.ErrNotFound {
+				r.logger.Tracef("DocMissing assertion failed for op: %#v", op)
+				return txn.ErrAborted
+			}
+		} else {
+			// Client side txns used to assert on txn-revno not changing once
+			// the document was 'prepared'. But we don't actually care, so
+			// we can just run the Assert as given.
+			qdoc := bson.D{{Name: "_id", Value: op.Id}}
+			// client-side txns use $or here, seems an odd choice.
+			qdoc = append(qdoc, bson.DocElem{"$or", []interface{}{op.Assert}})
+			if c.Find(qdoc).Select(idFields).One(nil) == mgo.ErrNotFound {
+				r.logger.Tracef("assertion failed for op: %#v", op)
+				return txn.ErrAborted
+			}
+		}
+	}
+	return nil
+}
+
+// objToDoc converts an arbitrary Struct/bson.D/bson.M to a pure bson.D by
+// Marshalling and Unmarshalling the document. We do this so we can add the
+// txn-revno field to the document.
+func objToDoc(obj interface{}) (d bson.D, err error) {
+	data, err := bson.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	err = bson.Unmarshal(data, &d)
+	if err != nil {
+		return nil, err
+	}
+	return d, err
+}
+
+// addToDoc will check if 'name' already exists in the doc, and if so, extend the
+// contents with value. Otherwise, it will append a new parameter with that name
+func addToDoc(doc bson.D, name string, value bson.D) (bson.D, error) {
+	for i := range doc {
+		if doc[i].Name == name {
+			if old, ok := doc[i].Value.(bson.D); ok {
+				doc[i].Value = append(old, value...)
+				return doc, nil
+			} else {
+				// TODO: test this
+				return nil, fmt.Errorf("invalid %q value in change document: %#v", name, doc[i].Value)
+			}
+		}
+	}
+	doc = append(doc, bson.DocElem{Name: name, Value: value})
+	return doc, nil
+}
+
+// setInDoc will check if 'name' already exists in the doc, and if so, replace
+// the value with the new value. Otherwise, it will append a new parameter
+func setInDoc(doc bson.D, name string, value interface{}) bson.D {
+	for i := range doc {
+		if doc[i].Name == name {
+			doc[i].Value = value
+			return doc
+		}
+	}
+	doc = append(doc, bson.DocElem{Name: name, Value: value})
+	return doc
+}
+
+func (r *Runner) applyOps(ops []txn.Op) error {
+	for _, op := range ops {
+		var err error
+		switch {
+		case op.Update != nil:
+			err = r.applyUpdate(op)
+		case op.Insert != nil:
+			err = r.applyInsert(op)
+		case op.Remove:
+			err = r.applyRemove(op)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Runner) applyUpdate(op txn.Op) error {
+	// XXX: do we need to track the revno of the doc from the time we did the Assert
+	// until we do this update? I'm hoping we don't as that is the point of
+	// using a server Transaction.
+	c := r.db.C(op.C)
+	r.logger.Tracef("update op: %#v", op)
+	d, err := objToDoc(op.Update)
+	if err != nil {
+		// TODO: Test unmarshallable Update
+		return err
+	}
+	r.logger.Tracef("raw update doc: %#v", d)
+	// Note: Mongo will accept this being passed in as an extra entry in d.
+	// We don't *have* to put it in the same "$inc" section. Might be nicer
+	// to be appending the content at the end.
+	d, err = addToDoc(d, "$inc", bson.D{{"txn-revno", 1}})
+	if err != nil {
+		return err
+	}
+	r.logger.Tracef("update doc: %#v", d)
+	err = c.UpdateId(op.Id, d)
+	if err == nil {
+		// happy path
+		return nil
+	} else {
+		r.logger.Tracef("op %#v error: %v", op, err)
+		return err
+	}
+}
+
+func (r *Runner) applyInsert(op txn.Op) error {
+	c := r.db.C(op.C)
+	r.logger.Tracef("inserting op: %#v", op)
+	// XXX: Do we need a txns.stash? Without one,
+	// Remove is permanent, and Insert won't create a doc with a greater revno
+	// However, txn pruner destroys objects in the stash anyway, and
+	// things still seem to work, so we probably don't
+	d, err := objToDoc(op.Insert)
+	if err != nil {
+		// TODO: Test unmarshallable Insert
+		return err
+	}
+	d = setInDoc(d, "_id", op.Id)
+	d = setInDoc(d, "txn-revno", 2)
+	err = c.Insert(d)
+	if err == nil {
+		// happy path
+		return nil
+	} else {
+		r.logger.Tracef("op %#v error: %v", op, err)
+		return err
+	}
+}
+
+func (r *Runner) applyRemove(op txn.Op) error {
+	c := r.db.C(op.C)
+	r.logger.Tracef("remove op: %#v", op)
+	err := c.RemoveId(op.Id)
+	if err == nil || err == mgo.ErrNotFound {
+		// happy path
+		// note that removing a non-existing object does *not* abort the transaction
+		return nil
+	} else {
+		// XXX: mgo.ErrNotFound is probably a no-op?
+		r.logger.Tracef("op %#v error: %v", op, err)
+		return err
+	}
+}
+
+func (r *Runner) updateLog(ops []txn.Op, txnId bson.ObjectId) error {
+	if r.logCollection == nil {
+		return nil
+	}
+	// TODO: we could determine the revno a cheaper way. Rather than reading all
+	//  the docs after we updated them, we could use somethnig like Apply to update
+	//  the documents and read back what the new revno is. Or we could read it
+	//  during the Assert stage and assert that it is going to the value we want
+	//  it to go to instead of using $inc.
+	//  This code causes us to reread all the documents we just wrote,
+	//  which isn't great.
+	logDoc := bson.D{{Name: "_id", Value: txnId}}
+	for _, op := range ops {
+		if op.Insert == nil && op.Update == nil && !op.Remove {
+			// this is assert only, so it isn't considered a change
+			continue
+		}
+		// Add change to the log document.
+		var dr bson.D
+		for li := range logDoc {
+			elem := &logDoc[li]
+			if elem.Name == op.C {
+				dr = elem.Value.(bson.D)
+				break
+			}
+		}
+		if dr == nil {
+			dr = bson.D{{"d", []interface{}{}}, {"r", []int64{}}}
+			logDoc = append(logDoc, bson.DocElem{op.C, dr})
+		}
+		c := r.db.C(op.C)
+		var rDoc revnoDoc
+		if err := c.FindId(op.Id).Select(revnoFields).One(&rDoc); err != nil {
+			if err == mgo.ErrNotFound {
+				rDoc.Revno = -1
+			} else {
+				return err
+			}
+		}
+		dr[0].Value = append(dr[0].Value.([]interface{}), op.Id)
+		dr[1].Value = append(dr[1].Value.([]int64), rDoc.Revno)
+	}
+	if err := r.logCollection.Insert(logDoc); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ChangeLog enables logging of changes to the given collection
+// every time a transaction that modifies content is done being
+// applied.
+//
+// Saved documents are in the format:
+//
+//     {"_id": <txn id>, <collection>: {"d": [<doc id>, ...], "r": [<doc revno>, ...]}}
+//
+// The document revision is the value of the txn-revno field after
+// the change has been applied. Negative values indicate the document
+// was not present in the collection. Revisions will not change when
+// updates or removes are applied to missing documents or inserts are
+// attempted when the document isn't present.
+func (r *Runner) ChangeLog(logc *mgo.Collection) {
+	r.logCollection = logc
+}

--- a/sstxn/sstxn.go
+++ b/sstxn/sstxn.go
@@ -87,8 +87,8 @@ func NewRunner(db *mgo.Database, logger Logger) *Runner {
 // down ahead of time to later verify the success of the change and
 // resume it, when the procedure is interrupted for any reason. If
 // empty, a random id will be generated.
-// The info parameter, if not nil, is included under the "i"
-// field of the transaction document.
+// The info parameter, is ignored, and only preserved for api compatibility
+// with client-side transaction Runner.Run()
 //
 // Operations across documents are not atomically applied, but are
 // guaranteed to be eventually all applied in the order provided or
@@ -102,7 +102,7 @@ func NewRunner(db *mgo.Database, logger Logger) *Runner {
 //
 // Any number of transactions may be run concurrently, with one
 // runner or many.
-func (r *Runner) Run(ops []txn.Op, id bson.ObjectId) (err error) {
+func (r *Runner) Run(ops []txn.Op, id bson.ObjectId, info interface{}) (err error) {
 	const efmt = "error in transaction op %d: %s"
 	for i := range ops {
 		op := &ops[i]
@@ -432,4 +432,9 @@ func (r *Runner) updateLog(ops []txn.Op, revnos []int64, txnId bson.ObjectId) er
 // attempted when the document isn't present.
 func (r *Runner) ChangeLog(logc *mgo.Collection) {
 	r.logCollection = logc
+}
+
+// ResumeAll is a no-op on server-side transactions because there is nothing to resume.
+func (r *Runner) ResumeAll() error {
+	return nil
 }

--- a/sstxn/sstxn_test.go
+++ b/sstxn/sstxn_test.go
@@ -1,0 +1,1163 @@
+// Copyright 2018 Canonical Ltd.
+
+package sstxn_test
+
+import (
+	"flag"
+	"fmt"
+	//	"sync"
+	"testing"
+	//	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/dbtest"
+	"gopkg.in/mgo.v2/sstxn"
+	"gopkg.in/mgo.v2/txn"
+)
+
+func TestAll(t *testing.T) {
+	TestingT(t)
+}
+
+var fast = flag.Bool("fast", false, "Skip slow tests")
+
+type S struct {
+	server   dbtest.DBServer
+	session  *mgo.Session
+	db       *mgo.Database
+	txnlog   *mgo.Collection
+	accounts *mgo.Collection
+	runner   *sstxn.Runner
+}
+
+var _ = Suite(&S{})
+
+type M map[string]interface{}
+
+type log_Logger interface {
+	Output(calldepth int, s string) error
+}
+
+func (s *S) SetUpSuite(c *C) {
+	// mongod running from juju-db.mongod cannot see /tmp
+	path := c.MkDir()
+	c.Logf("setting DB path to: %q", path)
+	s.server.SetPath(path)
+	s.server.EnableReplicaset("sstxn-test")
+}
+
+func (s *S) TearDownSuite(c *C) {
+	s.server.Stop()
+}
+
+type testLogger struct {
+	c *C
+}
+
+func (t *testLogger) Tracef(message string, args ...interface{}) {
+	t.logf("TRACE", message, args...)
+}
+func (t *testLogger) Debugf(message string, args ...interface{}) {
+	t.logf("DEBUG", message, args...)
+}
+func (t *testLogger) Infof(message string, args ...interface{}) {
+	t.logf("INFO", message, args...)
+}
+func (t *testLogger) Warningf(message string, args ...interface{}) {
+	t.logf("WARNING", message, args...)
+}
+func (t *testLogger) Errorf(message string, args ...interface{}) {
+	t.logf("ERROR", message, args...)
+}
+func (t *testLogger) Criticalf(message string, args ...interface{}) {
+	t.logf("CRITICAL", message, args...)
+}
+func (t *testLogger) logf(level, message string, args ...interface{}) {
+	t.c.Output(3, level+" "+fmt.Sprintf(message, args...))
+}
+
+func (s *S) SetUpTest(c *C) {
+	s.server.Wipe()
+
+	// txn.SetChaos(txn.Chaos{})
+	// txn.SetLogger(c)
+	// txn.SetDebug(true)
+
+	s.session = s.server.Session()
+	build, err := s.session.BuildInfo()
+	c.Assert(err, IsNil)
+	if !build.VersionAtLeast(4, 0) {
+		// Skip in SetUpTest means TearDownTest won't be run.
+		s.session.Close()
+		c.Skip("server side transactions only supported with Mongo 4.0")
+	}
+	s.db = s.session.DB("test")
+	s.txnlog = s.db.C("txn.log")
+	s.accounts = s.db.C("accounts")
+	s.accounts.Create(&mgo.CollectionInfo{})
+	s.runner = sstxn.NewRunner(s.db, &testLogger{c})
+}
+
+func (s *S) TearDownTest(c *C) {
+	s.session.Close()
+}
+
+type Account struct {
+	Id      int `bson:"_id"`
+	Balance int
+}
+
+func (s *S) TestDocExists(c *C) {
+	err := s.accounts.Insert(M{"_id": 0, "balance": 300})
+	c.Assert(err, IsNil)
+
+	exists := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Assert: txn.DocExists,
+	}}
+	missing := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Assert: txn.DocMissing,
+	}}
+
+	err = s.runner.Run(exists, "")
+	c.Assert(err, IsNil)
+	err = s.runner.Run(missing, "")
+	c.Assert(err, Equals, txn.ErrAborted)
+
+	err = s.accounts.RemoveId(0)
+	c.Assert(err, IsNil)
+
+	err = s.runner.Run(exists, "")
+	c.Assert(err, Equals, txn.ErrAborted)
+	err = s.runner.Run(missing, "")
+	c.Assert(err, IsNil)
+}
+
+func (s *S) TestInsert(c *C) {
+	err := s.accounts.Insert(M{"_id": 0, "balance": 300})
+	c.Assert(err, IsNil)
+
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Insert: M{"balance": 200},
+	}}
+
+	// NOTE: this differs from client-side transactions
+	// With client txns, Insert of an existing doc was ignored. With
+	// server side transactions, trying to insert a doc that already
+	// exists aborts the entire transaction, so we no longer hide
+	// that fact.
+	err = s.runner.Run(ops, "")
+	// TODO: Is "IsDup" or txn.ErrAborted better for clients to handle here?
+	// With a multi-document transaction, there is no context to know
+	// *which* document was a duplicate. (the ss txn code does know which,
+	// but we don't have a good way to feed that information back).
+	if !mgo.IsDup(err) {
+		c.Fatalf("expected Duplicate error, got: %v", err)
+	}
+
+	var account Account
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 300)
+
+	ops[0].Id = 1
+	err = s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	err = s.accounts.FindId(1).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 200)
+}
+
+func (s *S) TestInsertStructID(c *C) {
+	type id struct {
+		FirstName string
+		LastName  string
+	}
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     id{FirstName: "John", LastName: "Jones"},
+		Assert: txn.DocMissing,
+		Insert: M{"balance": 200},
+	}, {
+		C:      "accounts",
+		Id:     id{FirstName: "Sally", LastName: "Smith"},
+		Assert: txn.DocMissing,
+		Insert: M{"balance": 800},
+	}}
+
+	err := s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	n, err := s.accounts.Find(nil).Count()
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 2)
+}
+
+func (s *S) TestRemove(c *C) {
+	err := s.accounts.Insert(M{"_id": 0, "balance": 300})
+	c.Assert(err, IsNil)
+
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Remove: true,
+	}}
+
+	err = s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	err = s.accounts.FindId(0).One(nil)
+	c.Assert(err, Equals, mgo.ErrNotFound)
+
+	// Removing a non-existing doc does not abort the transaction,
+	// so we preserve the behavior.
+	err = s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+}
+
+func (s *S) TestUpdate(c *C) {
+	var err error
+	err = s.accounts.Insert(M{"_id": 0, "balance": 200})
+	c.Assert(err, IsNil)
+	err = s.accounts.Insert(M{"_id": 1, "balance": 200})
+	c.Assert(err, IsNil)
+
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$inc": M{"balance": 100}},
+	}}
+
+	err = s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	var account Account
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 300)
+
+	err = s.accounts.FindId(1).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 200)
+}
+
+func (s *S) TestInsertUpdate(c *C) {
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Insert: M{"balance": 200},
+	}, {
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$inc": M{"balance": 100}},
+	}}
+
+	err := s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	var account Account
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 300)
+
+	// Note: Differs from Client-side transactions.
+	// Since client TXN treats insert as a no-op, then the insert+update
+	// was causing the Update to happen, ignoring the invalid Insert.
+	// We no longer treat Insert as a no-op, so we don't
+	// run the Update.
+	err = s.runner.Run(ops, "")
+	c.Assert(err, NotNil)
+	if !mgo.IsDup(err) {
+		c.Errorf("expected Duplicate error, not: %v", err)
+	}
+
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 300)
+	// v- this is client-txn result
+	// c.Assert(account.Balance, Equals, 400)
+}
+
+func (s *S) TestUpdateInsert(c *C) {
+	c.Skip("client side transactions seems to have weird behavior here")
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$inc": M{"balance": 100}},
+	}, {
+		C:      "accounts",
+		Id:     0,
+		Insert: M{"balance": 200},
+	}}
+
+	err := s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	var account Account
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 200)
+
+	err = s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 300)
+}
+
+func (s *S) TestInsertRemoveInsert(c *C) {
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Insert: M{"_id": 0, "balance": 200},
+	}, {
+		C:      "accounts",
+		Id:     0,
+		Remove: true,
+	}, {
+		C:      "accounts",
+		Id:     0,
+		Insert: M{"_id": 0, "balance": 300},
+	}}
+
+	err := s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	var account Account
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 300)
+}
+
+func (s *S) TestErrors(c *C) {
+	doc := bson.M{"foo": 1}
+	tests := []txn.Op{{
+		C:  "c",
+		Id: 0,
+	}, {
+		C:      "c",
+		Id:     0,
+		Insert: doc,
+		Remove: true,
+	}, {
+		C:      "c",
+		Id:     0,
+		Insert: doc,
+		Update: doc,
+	}, {
+		C:      "c",
+		Id:     0,
+		Update: doc,
+		Remove: true,
+	}, {
+		C:      "c",
+		Assert: doc,
+	}, {
+		Id:     0,
+		Assert: doc,
+	}}
+
+	txn.SetChaos(txn.Chaos{KillChance: 1.0})
+	for _, op := range tests {
+		c.Logf("op: %v", op)
+		err := s.runner.Run([]txn.Op{op}, "")
+		c.Assert(err, ErrorMatches, "error in transaction op 0: .*")
+	}
+}
+
+func (s *S) TestAssertRefusesUpdate(c *C) {
+	c.Assert(s.accounts.Insert(M{"_id": 0, "balance": 100}), IsNil)
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Assert: bson.D{{"balance", 200}},
+		Update: bson.D{{"$inc", bson.D{{"balance", 100}}}},
+	}}
+	c.Assert(s.runner.Run(ops, ""), Equals, txn.ErrAborted)
+	var account Account
+	c.Assert(s.accounts.FindId(0).One(&account), IsNil)
+	c.Assert(account.Balance, Equals, 100)
+}
+
+func (s *S) TestAssertNestedOr(c *C) {
+	// Assert uses $or internally. Ensure nesting works.
+	err := s.accounts.Insert(M{"_id": 0, "balance": 100})
+	c.Assert(err, IsNil)
+
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Assert: bson.D{{"$or", []bson.D{{{"balance", 100}}, {{"balance", 300}}}}},
+		Update: bson.D{{"$inc", bson.D{{"balance", 100}}}},
+	}}
+
+	err = s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	var account Account
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 200)
+
+	err = s.runner.Run(ops, "")
+	c.Assert(err, Equals, txn.ErrAborted)
+
+	ops2 := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Assert: bson.D{{"balance", 200}},
+		Update: bson.D{{"$set", bson.D{{"balance", 300}}}},
+	}}
+	err = s.runner.Run(ops2, "")
+	c.Assert(err, IsNil)
+
+	// Now that we're at 300, the original ops should apply again
+	err = s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	err = s.accounts.FindId(0).One(&account)
+	c.Assert(err, IsNil)
+	c.Assert(account.Balance, Equals, 400)
+}
+
+func (s *S) TestInsertInvalidAssert(c *C) {
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Assert: bson.D{{"balance", 100}},
+		Insert: bson.D{{"balance", 100}},
+	}}
+
+	err := s.runner.Run(ops, "")
+	c.Assert(err, ErrorMatches, `Insert can only Assert txn.DocMissing not \[\{balance 100\}\]`)
+
+	ops = []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Assert: txn.DocExists,
+		Insert: bson.D{{"balance", 100}},
+	}}
+
+	err = s.runner.Run(ops, "")
+	c.Assert(err, ErrorMatches, "Insert can only Assert txn.DocMissing not txn.DocExists")
+}
+
+func (s *S) TestVerifyFieldOrdering(c *C) {
+	// Used to have a map in certain operations, which means
+	// the ordering of fields would be messed up.
+	fields := bson.D{{"a", 1}, {"b", 2}, {"c", 3}}
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Insert: fields,
+	}}
+
+	err := s.runner.Run(ops, "")
+	c.Assert(err, IsNil)
+
+	var d bson.D
+	err = s.accounts.FindId(0).One(&d)
+	c.Assert(err, IsNil)
+
+	var filtered bson.D
+	for _, e := range d {
+		switch e.Name {
+		case "a", "b", "c":
+			filtered = append(filtered, e)
+		}
+	}
+	c.Assert(filtered, DeepEquals, fields)
+}
+
+func (s *S) TestChangeLog(c *C) {
+	c.Assert(s.db.C("people").Create(&mgo.CollectionInfo{}), IsNil)
+	c.Assert(s.db.C("debts").Create(&mgo.CollectionInfo{}), IsNil)
+	c.Assert(s.db.C("chglog").Create(&mgo.CollectionInfo{
+		Capped:   true,
+		MaxBytes: 1e6,
+	}), IsNil)
+	chglog := s.db.C("chglog")
+	s.runner.ChangeLog(chglog)
+
+	ops := []txn.Op{{
+		C:      "debts",
+		Id:     0,
+		Assert: txn.DocMissing,
+	}, {
+		C:      "accounts",
+		Id:     0,
+		Insert: M{"balance": 300},
+	}, {
+		C:      "accounts",
+		Id:     1,
+		Insert: M{"balance": 300},
+	}, {
+		C:      "people",
+		Id:     "joe",
+		Insert: M{"accounts": []int64{0, 1}},
+	}}
+	id := bson.NewObjectId()
+	err := s.runner.Run(ops, id)
+	c.Assert(err, IsNil)
+
+	type IdList []interface{}
+	type Log struct {
+		Docs   IdList  "d"
+		Revnos []int64 "r"
+	}
+	var m map[string]*Log
+	err = chglog.FindId(id).One(&m)
+	c.Assert(err, IsNil)
+
+	c.Assert(m["accounts"], DeepEquals, &Log{IdList{0, 1}, []int64{2, 2}})
+	c.Assert(m["people"], DeepEquals, &Log{IdList{"joe"}, []int64{2}})
+	c.Assert(m["debts"], IsNil)
+
+	ops = []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Update: M{"$inc": M{"balance": 100}},
+	}, {
+		C:      "accounts",
+		Id:     1,
+		Update: M{"$inc": M{"balance": 100}},
+	}}
+	id = bson.NewObjectId()
+	err = s.runner.Run(ops, id)
+	c.Assert(err, IsNil)
+
+	m = nil
+	err = chglog.FindId(id).One(&m)
+	c.Assert(err, IsNil)
+
+	c.Assert(m["accounts"], DeepEquals, &Log{IdList{0, 1}, []int64{3, 3}})
+	c.Assert(m["people"], IsNil)
+
+	ops = []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Remove: true,
+	}, {
+		C:      "people",
+		Id:     "joe",
+		Remove: true,
+	}}
+	id = bson.NewObjectId()
+	err = s.runner.Run(ops, id)
+	c.Assert(err, IsNil)
+
+	m = nil
+	err = chglog.FindId(id).One(&m)
+	c.Assert(err, IsNil)
+
+	c.Assert(m["accounts"], DeepEquals, &Log{IdList{0}, []int64{-1}})
+	c.Assert(m["people"], DeepEquals, &Log{IdList{"joe"}, []int64{-1}})
+}
+
+//
+// func (s *S) TestTxnQueueStashStressTest(c *C) {
+// 	if *fast {
+// 		c.Skip("-fast was supplied and this test is slow")
+// 	}
+// 	txn.SetChaos(txn.Chaos{
+// 		SlowdownChance: 0.3,
+// 		Slowdown:       50 * time.Millisecond,
+// 	})
+// 	defer txn.SetChaos(txn.Chaos{})
+//
+// 	// So we can run more iterations of the test in less time.
+// 	txn.SetDebug(false)
+//
+// 	const runners = 10
+// 	const inserts = 10
+// 	const repeat = 100
+//
+// 	for r := 0; r < repeat; r++ {
+// 		var wg sync.WaitGroup
+// 		wg.Add(runners)
+// 		for i := 0; i < runners; i++ {
+// 			go func(i, r int) {
+// 				defer wg.Done()
+//
+// 				session := s.session.New()
+// 				defer session.Close()
+// 				runner := txn.NewRunner(s.tc.With(session))
+//
+// 				for j := 0; j < inserts; j++ {
+// 					ops := []txn.Op{{
+// 						C:  "accounts",
+// 						Id: fmt.Sprintf("insert-%d-%d", r, j),
+// 						Insert: bson.M{
+// 							"added-by": i,
+// 						},
+// 					}}
+// 					err := runner.Run(ops, "", nil)
+// 					if err != txn.ErrAborted {
+// 						c.Check(err, IsNil)
+// 					}
+// 				}
+// 			}(i, r)
+// 		}
+// 		wg.Wait()
+// 	}
+// }
+//
+// func (s *S) checkTxnQueueLength(c *C, expectedQueueLength int) {
+// 	txn.SetDebug(false)
+// 	txn.SetChaos(txn.Chaos{
+// 		KillChance: 1,
+// 		Breakpoint: "set-applying",
+// 	})
+// 	defer txn.SetChaos(txn.Chaos{})
+// 	err := s.accounts.Insert(M{"_id": 0, "balance": 100})
+// 	c.Assert(err, IsNil)
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$inc": M{"balance": 100}},
+// 	}}
+// 	for i := 0; i < expectedQueueLength; i++ {
+// 		err := s.runner.Run(ops, "", nil)
+// 		c.Assert(err, Equals, txn.ErrChaos)
+// 	}
+// 	txn.SetDebug(true)
+// 	// Now that we've filled up the queue, we should see that there are 1000
+// 	// items in the queue, and the error applying a new one will change.
+// 	var doc bson.M
+// 	err = s.accounts.FindId(0).One(&doc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedQueueLength)
+// 	err = s.runner.Run(ops, "", nil)
+// 	c.Check(err, ErrorMatches, `txn-queue for 0 in "accounts" has too many transactions \(\d+\)`)
+// 	// The txn-queue should not have grown
+// 	err = s.accounts.FindId(0).One(&doc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedQueueLength)
+// }
+//
+// func (s *S) TestTxnQueueDefaultMaxSize(c *C) {
+// 	s.runner.SetOptions(txn.DefaultRunnerOptions())
+// 	s.checkTxnQueueLength(c, 1000)
+// }
+//
+// func (s *S) TestTxnQueueCustomMaxSize(c *C) {
+// 	opts := txn.DefaultRunnerOptions()
+// 	opts.MaxTxnQueueLength = 100
+// 	s.runner.SetOptions(opts)
+// 	s.checkTxnQueueLength(c, 100)
+// }
+//
+// func (s *S) TestTxnQueueMultipleDocs(c *C) {
+// 	expectedLength := 100
+// 	maxDocs := 110
+// 	opts := txn.DefaultRunnerOptions()
+// 	opts.MaxTxnQueueLength = expectedLength
+// 	s.runner.SetOptions(opts)
+// 	txn.SetDebug(false)
+// 	createOps := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Insert: M{"balance": 1000},
+// 	}}
+// 	for i := 1; i < maxDocs; i++ {
+// 		createOps = append(createOps, txn.Op{
+// 			C:      "accounts",
+// 			Id:     i,
+// 			Insert: M{"balance": 0},
+// 		})
+// 	}
+// 	err := s.runner.Run(createOps, "", nil)
+// 	c.Assert(err, IsNil)
+// 	// Force a bad transaction into the queue
+// 	badTxnId := "deadbeef1234567812345678_12345678"
+// 	err = s.accounts.UpdateId(0, M{"$set": M{"txn-queue": []string{badTxnId}}})
+// 	c.Assert(err, IsNil)
+// 	for i := 1; i < expectedLength; i++ {
+// 		ops := []txn.Op{{
+// 			C:      "accounts",
+// 			Id:     0,
+// 			Update: M{"$inc": M{"balance": -1}},
+// 		}, {
+// 			C:      "accounts",
+// 			Id:     i,
+// 			Update: M{"$inc": M{"balance": 1}},
+// 		}}
+// 		err = s.runner.Run(ops, "", nil)
+// 		c.Assert(err, NotNil)
+// 		c.Assert(err, ErrorMatches, `cannot find transaction ObjectIdHex."deadbeef1234567812345678".`)
+// 	}
+// 	// Now that we've filled up the txn-queue of the first document, any
+// 	// further changes should be aborted
+// 	var doc bson.M
+// 	err = s.accounts.FindId(0).One(&doc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedLength)
+// 	txn.SetDebug(true)
+// 	for i := 100; i < maxDocs; i++ {
+// 		ops := []txn.Op{{
+// 			C:      "accounts",
+// 			Id:     0,
+// 			Update: M{"$inc": M{"balance": -1}},
+// 		}, {
+// 			C:      "accounts",
+// 			Id:     i,
+// 			Update: M{"$inc": M{"balance": 1}},
+// 		}}
+// 		err = s.runner.Run(ops, "", nil)
+// 		c.Assert(err, NotNil)
+// 		c.Check(err, ErrorMatches, `txn-queue for 0 in "accounts" has too many transactions \(\d+\)`)
+// 	}
+// 	err = s.accounts.FindId(0).One(&doc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedLength)
+// 	err = s.accounts.UpdateId(0, M{"$pullAll": M{"txn-queue": []string{badTxnId}}})
+// 	c.Assert(err, IsNil)
+// 	c.Log("Updated removing the invalid transaction")
+// 	// Now we should be able to cleanup
+// 	err = s.runner.ResumeAll()
+// 	c.Assert(err, IsNil)
+// 	c.Log("resumed all")
+// }
+//
+// func (s *S) TestTxnQueueUnlimited(c *C) {
+// 	opts := txn.DefaultRunnerOptions()
+// 	// A value of 0 should mean 'unlimited'
+// 	opts.MaxTxnQueueLength = 0
+// 	s.runner.SetOptions(opts)
+// 	// it isn't possible to actually prove 'unlimited' but we can prove that
+// 	// we at least can insert more than the default number of transactions
+// 	// without getting a 'too many transactions' failure.
+// 	txn.SetDebug(false)
+// 	txn.SetChaos(txn.Chaos{
+// 		KillChance: 1,
+// 		// Use set-prepared because we are adding more transactions than
+// 		// other tests, and this speeds up setup time a bit
+// 		Breakpoint: "set-prepared",
+// 	})
+// 	defer txn.SetChaos(txn.Chaos{})
+// 	err := s.accounts.Insert(M{"_id": 0, "balance": 100})
+// 	c.Assert(err, IsNil)
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$inc": M{"balance": 100}},
+// 	}}
+// 	for i := 0; i < 1100; i++ {
+// 		err := s.runner.Run(ops, "", nil)
+// 		c.Assert(err, Equals, txn.ErrChaos)
+// 	}
+// 	txn.SetDebug(true)
+// 	var doc bson.M
+// 	err = s.accounts.FindId(0).One(&doc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(doc["txn-queue"].([]interface{})), Equals, 1100)
+// 	err = s.runner.Run(ops, "", nil)
+// 	c.Check(err, Equals, txn.ErrChaos)
+// 	err = s.accounts.FindId(0).One(&doc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(doc["txn-queue"].([]interface{})), Equals, 1101)
+// }
+//
+// func (s *S) TestTxnQueueAssertionsDefault(c *C) {
+// 	opts := txn.DefaultRunnerOptions()
+// 	// We force the MaxTxnQueueLength to be shorter, so we don't have to do
+// 	// as many iterations to get it to fail.
+// 	// Without any default pruning, the queue on the assert-only document
+// 	// will grow longer than this length, and that will cause transactions
+// 	// to stop being applied.
+// 	opts.MaxTxnQueueLength = 500
+// 	s.runner.SetOptions(opts)
+// 	// By default we should prevent a txn-queue from growing too large
+// 	txn.SetDebug(false)
+// 	c.Assert(s.accounts.Insert(M{"_id": 0, "balance": 100}), IsNil)
+// 	c.Assert(s.accounts.Insert(M{"_id": 1, "balance": 100}), IsNil)
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Assert: M{"balance": 100},
+// 	}, {
+// 		C:      "accounts",
+// 		Id:     1,
+// 		Update: M{"$inc": M{"balance": 1}},
+// 	}}
+// 	for i := 0; i < 600; i++ {
+// 		c.Assert(s.runner.Run(ops, "", nil), IsNil)
+// 	}
+// 	var a0 txnQueue
+// 	c.Assert(s.accounts.FindId(0).One(&a0), IsNil)
+// 	var a1 txnQueue
+// 	c.Assert(s.accounts.FindId(1).One(&a1), IsNil)
+// 	c.Check(len(a0.Queue) < 500, Equals, true,
+// 		Commentf("txn-queue grew too long: len=%d", len(a0.Queue)))
+// 	c.Check(len(a1.Queue) < 500, Equals, true,
+// 		Commentf("txn-queue grew too long: len=%d", len(a1.Queue)))
+// }
+//
+// func (s *S) TestTxnQueueAssertionsCustomValue(c *C) {
+// 	opts := txn.DefaultRunnerOptions()
+// 	opts.AssertionCleanupLength = 17
+// 	s.runner.SetOptions(opts)
+// 	// By default we should prevent a txn-queue from growing too large
+// 	txn.SetDebug(false)
+// 	c.Assert(s.accounts.Insert(M{"_id": 0, "balance": 100}), IsNil)
+// 	c.Assert(s.accounts.Insert(M{"_id": 1, "balance": 100}), IsNil)
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Assert: M{"balance": 100},
+// 	}, {
+// 		C:      "accounts",
+// 		Id:     1,
+// 		Update: M{"$inc": M{"balance": 1}},
+// 	}}
+// 	for i := 0; i < 100; i++ {
+// 		c.Assert(s.runner.Run(ops, "", nil), IsNil)
+// 	}
+// 	var a0 txnQueue
+// 	c.Assert(s.accounts.FindId(0).One(&a0), IsNil)
+// 	var a1 txnQueue
+// 	c.Assert(s.accounts.FindId(1).One(&a1), IsNil)
+// 	c.Check(len(a0.Queue) <= 17, Equals, true,
+// 		Commentf("txn-queue grew too long: len=%d", len(a0.Queue)))
+// 	c.Check(len(a1.Queue) <= 17, Equals, true,
+// 		Commentf("txn-queue grew too long: len=%d", len(a1.Queue)))
+// }
+//
+// func (s *S) TestTxnQueueAssertionsDisabled(c *C) {
+// 	opts := txn.DefaultRunnerOptions()
+// 	opts.AssertionCleanupLength = 0
+// 	s.runner.SetOptions(opts)
+// 	// By default we should prevent a txn-queue from growing too large
+// 	txn.SetDebug(false)
+// 	c.Assert(s.accounts.Insert(M{"_id": 0, "balance": 100}), IsNil)
+// 	c.Assert(s.accounts.Insert(M{"_id": 1, "balance": 100}), IsNil)
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Assert: M{"balance": 100},
+// 	}, {
+// 		C:      "accounts",
+// 		Id:     1,
+// 		Update: M{"$inc": M{"balance": 1}},
+// 	}}
+// 	for i := 0; i < 200; i++ {
+// 		c.Assert(s.runner.Run(ops, "", nil), IsNil)
+// 	}
+// 	var a0 txnQueue
+// 	c.Assert(s.accounts.FindId(0).One(&a0), IsNil)
+// 	c.Check(len(a0.Queue), Equals, 200,
+// 		Commentf("queue length did not match expected %d: actual: %d", 200, len(a0.Queue)))
+// }
+//
+// func (s *S) TestPurgeMissingPipelineSizeLimit(c *C) {
+// 	// This test ensures that PurgeMissing can handle very large
+// 	// txn-queue fields. Previous iterations of PurgeMissing would
+// 	// trigger a 16MB aggregation pipeline result size limit when run
+// 	// against a documents or stashes with large numbers of txn-queue
+// 	// entries. PurgeMissing now no longer uses aggregation pipelines
+// 	// to work around this limit.
+//
+// 	// The pipeline result size limitation was removed from MongoDB in 2.6 so
+// 	// this test is only run for older MongoDB version.
+// 	build, err := s.session.BuildInfo()
+// 	c.Assert(err, IsNil)
+// 	if build.VersionAtLeast(2, 6) {
+// 		c.Skip("This tests a problem that can only happen with MongoDB < 2.6 ")
+// 	}
+//
+// 	// Insert a single document to work with.
+// 	err = s.accounts.Insert(M{"_id": 0, "balance": 100})
+// 	c.Assert(err, IsNil)
+//
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$inc": M{"balance": 100}},
+// 	}}
+//
+// 	// Generate one successful transaction.
+// 	good := bson.NewObjectId()
+// 	c.Logf("---- Running ops under transaction %q", good.Hex())
+// 	err = s.runner.Run(ops, good, nil)
+// 	c.Assert(err, IsNil)
+//
+// 	// Generate another transaction which which will go missing.
+// 	missing := bson.NewObjectId()
+// 	c.Logf("---- Running ops under transaction %q (which will go missing)", missing.Hex())
+// 	err = s.runner.Run(ops, missing, nil)
+// 	c.Assert(err, IsNil)
+//
+// 	err = s.tc.RemoveId(missing)
+// 	c.Assert(err, IsNil)
+//
+// 	// Generate a txn-queue on the test document that's large enough
+// 	// that it used to cause PurgeMissing to exceed MongoDB's pipeline
+// 	// result 16MB size limit (MongoDB 2.4 and older only).
+// 	//
+// 	// The contents of the txn-queue field doesn't matter, only that
+// 	// it's big enough to trigger the size limit. The required size
+// 	// can also be achieved by using multiple documents as long as the
+// 	// cumulative size of all the txn-queue fields exceeds the
+// 	// pipeline limit. A single document is easier to work with for
+// 	// this test however.
+// 	//
+// 	// The txn id of the successful transaction is used fill the
+// 	// txn-queue because this takes advantage of a short circuit in
+// 	// PurgeMissing, dramatically speeding up the test run time.
+// 	const fakeQueueLen = 250000
+// 	fakeTxnQueue := make([]string, fakeQueueLen)
+// 	token := good.Hex() + "_12345678" // txn id + nonce
+// 	for i := 0; i < fakeQueueLen; i++ {
+// 		fakeTxnQueue[i] = token
+// 	}
+//
+// 	err = s.accounts.UpdateId(0, bson.M{
+// 		"$set": bson.M{"txn-queue": fakeTxnQueue},
+// 	})
+// 	c.Assert(err, IsNil)
+//
+// 	// PurgeMissing could hit the same pipeline result size limit when
+// 	// processing the txn-queue fields of stash documents so insert
+// 	// the large txn-queue there too to ensure that no longer happens.
+// 	err = s.sc.Insert(
+// 		bson.D{{"c", "accounts"}, {"id", 0}},
+// 		bson.M{"txn-queue": fakeTxnQueue},
+// 	)
+// 	c.Assert(err, IsNil)
+//
+// 	c.Logf("---- Purging missing transactions")
+// 	err = s.runner.PurgeMissing("accounts")
+// 	c.Assert(err, IsNil)
+// }
+//
+// var flaky = flag.Bool("flaky", false, "Include flaky tests")
+// var txnQueueLength = flag.Int("qlength", 100, "txn-queue length for tests")
+//
+// func (s *S) TestTxnQueueStressTest(c *C) {
+// 	// This fails about 20% of the time on Mongo 3.2 (I haven't tried
+// 	// other versions) with account balance being 3999 instead of
+// 	// 4000. That implies that some updates are being lost. This is
+// 	// bad and we'll need to chase it down in the near future - the
+// 	// only reason it's being skipped now is that it's already failing
+// 	// and it's better to have the txn tests running without this one
+// 	// than to have them not running at all.
+// 	if !*flaky {
+// 		c.Skip("Fails intermittently - disabling until fixed")
+// 	}
+// 	txn.SetChaos(txn.Chaos{
+// 		SlowdownChance: 0.3,
+// 		Slowdown:       50 * time.Millisecond,
+// 	})
+// 	defer txn.SetChaos(txn.Chaos{})
+//
+// 	// So we can run more iterations of the test in less time.
+// 	txn.SetDebug(false)
+//
+// 	err := s.accounts.Insert(M{"_id": 0, "balance": 0}, M{"_id": 1, "balance": 0})
+// 	c.Assert(err, IsNil)
+//
+// 	// Run half of the operations changing account 0 and then 1,
+// 	// and the other half in the opposite order.
+// 	ops01 := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$inc": M{"balance": 1}},
+// 	}, {
+// 		C:      "accounts",
+// 		Id:     1,
+// 		Update: M{"$inc": M{"balance": 1}},
+// 	}}
+//
+// 	ops10 := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     1,
+// 		Update: M{"$inc": M{"balance": 1}},
+// 	}, {
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$inc": M{"balance": 1}},
+// 	}}
+//
+// 	ops := [][]txn.Op{ops01, ops10}
+//
+// 	const runners = 4
+// 	const changes = 1000
+//
+// 	var wg sync.WaitGroup
+// 	wg.Add(runners)
+// 	for n := 0; n < runners; n++ {
+// 		n := n
+// 		go func() {
+// 			defer wg.Done()
+// 			for i := 0; i < changes; i++ {
+// 				err = s.runner.Run(ops[n%2], "", nil)
+// 				c.Assert(err, IsNil)
+// 			}
+// 		}()
+// 	}
+// 	wg.Wait()
+//
+// 	for id := 0; id < 2; id++ {
+// 		var account Account
+// 		err = s.accounts.FindId(id).One(&account)
+// 		if account.Balance != runners*changes {
+// 			c.Errorf("Account should have balance of %d, got %d", runners*changes, account.Balance)
+// 		}
+// 	}
+// }
+//
+// type txnQueue struct {
+// 	Queue []string `bson:"txn-queue"`
+// }
+//
+// func (s *S) TestTxnQueueAssertionGrowth(c *C) {
+// 	txn.SetDebug(false) // too much spam
+// 	opts := txn.DefaultRunnerOptions()
+// 	// Disable automatic cleanup of queue, so that we can see the queue
+// 	// properly cleared on update.
+// 	opts.AssertionCleanupLength = 0
+// 	s.runner.SetOptions(opts)
+// 	err := s.accounts.Insert(M{"_id": 0, "balance": 0})
+// 	c.Assert(err, IsNil)
+// 	// Create many assertion only transactions.
+// 	t := time.Now()
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Assert: M{"balance": 0},
+// 	}}
+// 	for n := 0; n < *txnQueueLength; n++ {
+// 		err = s.runner.Run(ops, "", nil)
+// 		c.Assert(err, IsNil)
+// 	}
+// 	var qdoc txnQueue
+// 	err = s.accounts.FindId(0).One(&qdoc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(qdoc.Queue), Equals, *txnQueueLength)
+// 	c.Logf("%8.3fs to set up %d assertions", time.Since(t).Seconds(), *txnQueueLength)
+// 	t = time.Now()
+// 	txn.SetChaos(txn.Chaos{})
+// 	ops = []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$inc": M{"balance": 100}},
+// 	}}
+// 	err = s.runner.Run(ops, "", nil)
+// 	c.Logf("%8.3fs to clear N=%d assertions and add one more txn",
+// 		time.Since(t).Seconds(), *txnQueueLength)
+// 	err = s.accounts.FindId(0).One(&qdoc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(qdoc.Queue), Equals, 1)
+// }
+//
+// func (s *S) TestTxnQueueBrokenPrepared(c *C) {
+// 	txn.SetDebug(false) // too much spam
+// 	badTxnToken := "123456789012345678901234_deadbeef"
+// 	err := s.accounts.Insert(M{"_id": 0, "balance": 0, "txn-queue": []string{badTxnToken}})
+// 	c.Assert(err, IsNil)
+// 	t := time.Now()
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$set": M{"balance": 0}},
+// 	}}
+// 	errString := `cannot find transaction ObjectIdHex("123456789012345678901234")`
+// 	for n := 0; n < *txnQueueLength; n++ {
+// 		err = s.runner.Run(ops, "", nil)
+// 		c.Assert(err.Error(), Equals, errString)
+// 	}
+// 	var qdoc txnQueue
+// 	err = s.accounts.FindId(0).One(&qdoc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(qdoc.Queue), Equals, *txnQueueLength+1)
+// 	c.Logf("%8.3fs to set up %d 'prepared' txns", time.Since(t).Seconds(), *txnQueueLength)
+// 	t = time.Now()
+// 	s.accounts.UpdateId(0, bson.M{"$pullAll": bson.M{"txn-queue": []string{badTxnToken}}})
+// 	ops = []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$inc": M{"balance": 100}},
+// 	}}
+// 	err = s.runner.ResumeAll()
+// 	c.Assert(err, IsNil)
+// 	c.Logf("%8.3fs to ResumeAll N=%d 'prepared' txns",
+// 		time.Since(t).Seconds(), *txnQueueLength)
+// 	err = s.accounts.FindId(0).One(&qdoc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(qdoc.Queue), Equals, 1)
+// }
+//
+// func (s *S) TestTxnQueuePreparing(c *C) {
+// 	txn.SetDebug(false) // too much spam
+// 	err := s.accounts.Insert(M{"_id": 0, "balance": 0, "txn-queue": []string{}})
+// 	c.Assert(err, IsNil)
+// 	t := time.Now()
+// 	txn.SetChaos(txn.Chaos{
+// 		KillChance: 1.0,
+// 		Breakpoint: "set-prepared",
+// 	})
+// 	ops := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Update: M{"$set": M{"balance": 0}},
+// 	}}
+// 	for n := 0; n < *txnQueueLength; n++ {
+// 		err = s.runner.Run(ops, "", nil)
+// 		c.Assert(err, Equals, txn.ErrChaos)
+// 	}
+// 	var qdoc txnQueue
+// 	err = s.accounts.FindId(0).One(&qdoc)
+// 	c.Assert(err, IsNil)
+// 	c.Check(len(qdoc.Queue), Equals, *txnQueueLength)
+// 	c.Logf("%8.3fs to set up %d 'preparing' txns", time.Since(t).Seconds(), *txnQueueLength)
+// 	txn.SetChaos(txn.Chaos{})
+// 	t = time.Now()
+// 	err = s.runner.ResumeAll()
+// 	c.Logf("%8.3fs to ResumeAll N=%d 'preparing' txns",
+// 		time.Since(t).Seconds(), *txnQueueLength)
+// 	err = s.accounts.FindId(0).One(&qdoc)
+// 	c.Assert(err, IsNil)
+// 	expectedCount := 100
+// 	if *txnQueueLength <= expectedCount {
+// 		expectedCount = *txnQueueLength - 1
+// 	}
+// 	c.Check(len(qdoc.Queue), Equals, expectedCount)
+// }
+//
+// func (s *S) TestTxnQueueAddAndRemove(c *C) {
+// 	opts := txn.DefaultRunnerOptions()
+// 	opts.MaxTxnQueueLength = 10
+// 	s.runner.SetOptions(opts)
+// 	opInsert := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Insert: M{"balance": 0},
+// 	}}
+// 	opRemove := []txn.Op{{
+// 		C:      "accounts",
+// 		Id:     0,
+// 		Remove: true,
+// 	}}
+// 	err := s.runner.Run(opInsert, "", nil)
+// 	c.Assert(err, IsNil)
+// 	for n := 0; n < 10; n++ {
+// 		err = s.runner.Run(opRemove, "", nil)
+// 		c.Assert(err, IsNil)
+// 		err = s.runner.Run(opInsert, "", nil)
+// 		c.Assert(err, IsNil)
+// 	}
+// 	var qdoc txnQueue
+// 	err = s.accounts.FindId(0).One(&qdoc)
+// 	c.Assert(err, IsNil)
+// 	// Both Remove and Insert should prune all the completed transactions
+// 	c.Check(len(qdoc.Queue), Equals, 1)
+// }

--- a/sstxn/sstxn_test.go
+++ b/sstxn/sstxn_test.go
@@ -123,17 +123,17 @@ func (s *S) TestDocExists(c *C) {
 		Assert: txn.DocMissing,
 	}}
 
-	err = s.runner.Run(exists, "")
+	err = s.runner.Run(exists, "", nil)
 	c.Assert(err, IsNil)
-	err = s.runner.Run(missing, "")
+	err = s.runner.Run(missing, "", nil)
 	c.Assert(err, Equals, txn.ErrAborted)
 
 	err = s.accounts.RemoveId(0)
 	c.Assert(err, IsNil)
 
-	err = s.runner.Run(exists, "")
+	err = s.runner.Run(exists, "", nil)
 	c.Assert(err, Equals, txn.ErrAborted)
-	err = s.runner.Run(missing, "")
+	err = s.runner.Run(missing, "", nil)
 	c.Assert(err, IsNil)
 }
 
@@ -152,7 +152,7 @@ func (s *S) TestInsert(c *C) {
 	// server side transactions, trying to insert a doc that already
 	// exists aborts the entire transaction, so we no longer hide
 	// that fact.
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, Equals, txn.ErrAborted)
 
 	var account Account
@@ -161,7 +161,7 @@ func (s *S) TestInsert(c *C) {
 	c.Assert(account.Balance, Equals, 300)
 
 	ops[0].Id = 1
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	err = s.accounts.FindId(1).One(&account)
@@ -186,7 +186,7 @@ func (s *S) TestInsertStructID(c *C) {
 		Insert: M{"balance": 800},
 	}}
 
-	err := s.runner.Run(ops, "")
+	err := s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	n, err := s.accounts.Find(nil).Count()
@@ -204,7 +204,7 @@ func (s *S) TestRemove(c *C) {
 		Remove: true,
 	}}
 
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	err = s.accounts.FindId(0).One(nil)
@@ -212,7 +212,7 @@ func (s *S) TestRemove(c *C) {
 
 	// Removing a non-existing doc does not abort the transaction,
 	// so we preserve the behavior.
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 }
 
@@ -229,7 +229,7 @@ func (s *S) TestUpdate(c *C) {
 		Update: M{"$inc": M{"balance": 100}},
 	}}
 
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	var account Account
@@ -253,7 +253,7 @@ func (s *S) TestInsertUpdate(c *C) {
 		Update: M{"$inc": M{"balance": 100}},
 	}}
 
-	err := s.runner.Run(ops, "")
+	err := s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	var account Account
@@ -266,7 +266,7 @@ func (s *S) TestInsertUpdate(c *C) {
 	// was causing the Update to happen, ignoring the invalid Insert.
 	// We no longer treat Insert as a no-op, so we don't
 	// run the Update.
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, Equals, txn.ErrAborted)
 
 	err = s.accounts.FindId(0).One(&account)
@@ -288,7 +288,7 @@ func (s *S) TestUpdateInsert(c *C) {
 		Insert: M{"balance": 200},
 	}}
 
-	err := s.runner.Run(ops, "")
+	err := s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	var account Account
@@ -296,7 +296,7 @@ func (s *S) TestUpdateInsert(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(account.Balance, Equals, 200)
 
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	err = s.accounts.FindId(0).One(&account)
@@ -319,7 +319,7 @@ func (s *S) TestInsertRemoveInsert(c *C) {
 		Insert: M{"_id": 0, "balance": 300},
 	}}
 
-	err := s.runner.Run(ops, "")
+	err := s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	var account Account
@@ -359,7 +359,7 @@ func (s *S) TestErrors(c *C) {
 	txn.SetChaos(txn.Chaos{KillChance: 1.0})
 	for _, op := range tests {
 		c.Logf("op: %v", op)
-		err := s.runner.Run([]txn.Op{op}, "")
+		err := s.runner.Run([]txn.Op{op}, "", nil)
 		c.Assert(err, ErrorMatches, "error in transaction op 0: .*")
 	}
 }
@@ -372,7 +372,7 @@ func (s *S) TestAssertRefusesUpdate(c *C) {
 		Assert: bson.D{{"balance", 200}},
 		Update: bson.D{{"$inc", bson.D{{"balance", 100}}}},
 	}}
-	c.Assert(s.runner.Run(ops, ""), Equals, txn.ErrAborted)
+	c.Assert(s.runner.Run(ops, "", nil), Equals, txn.ErrAborted)
 	var account Account
 	c.Assert(s.accounts.FindId(0).One(&account), IsNil)
 	c.Assert(account.Balance, Equals, 100)
@@ -390,7 +390,7 @@ func (s *S) TestAssertNestedOr(c *C) {
 		Update: bson.D{{"$inc", bson.D{{"balance", 100}}}},
 	}}
 
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	var account Account
@@ -398,7 +398,7 @@ func (s *S) TestAssertNestedOr(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(account.Balance, Equals, 200)
 
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, Equals, txn.ErrAborted)
 
 	ops2 := []txn.Op{{
@@ -407,11 +407,11 @@ func (s *S) TestAssertNestedOr(c *C) {
 		Assert: bson.D{{"balance", 200}},
 		Update: bson.D{{"$set", bson.D{{"balance", 300}}}},
 	}}
-	err = s.runner.Run(ops2, "")
+	err = s.runner.Run(ops2, "", nil)
 	c.Assert(err, IsNil)
 
 	// Now that we're at 300, the original ops should apply again
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	err = s.accounts.FindId(0).One(&account)
@@ -427,7 +427,7 @@ func (s *S) TestInsertInvalidAssert(c *C) {
 		Insert: bson.D{{"balance", 100}},
 	}}
 
-	err := s.runner.Run(ops, "")
+	err := s.runner.Run(ops, "", nil)
 	c.Assert(err, ErrorMatches, `Insert can only Assert txn.DocMissing not \[\{balance 100\}\]`)
 
 	ops = []txn.Op{{
@@ -437,7 +437,7 @@ func (s *S) TestInsertInvalidAssert(c *C) {
 		Insert: bson.D{{"balance", 100}},
 	}}
 
-	err = s.runner.Run(ops, "")
+	err = s.runner.Run(ops, "", nil)
 	c.Assert(err, ErrorMatches, "Insert can only Assert txn.DocMissing not txn.DocExists")
 }
 
@@ -451,7 +451,7 @@ func (s *S) TestVerifyFieldOrdering(c *C) {
 		Insert: fields,
 	}}
 
-	err := s.runner.Run(ops, "")
+	err := s.runner.Run(ops, "", nil)
 	c.Assert(err, IsNil)
 
 	var d bson.D
@@ -496,7 +496,7 @@ func (s *S) TestChangeLog(c *C) {
 		Insert: M{"accounts": []int64{0, 1}},
 	}}
 	id := bson.NewObjectId()
-	err := s.runner.Run(ops, id)
+	err := s.runner.Run(ops, id, nil)
 	c.Assert(err, IsNil)
 
 	type IdList []interface{}
@@ -522,7 +522,7 @@ func (s *S) TestChangeLog(c *C) {
 		Update: M{"$inc": M{"balance": 100}},
 	}}
 	id = bson.NewObjectId()
-	err = s.runner.Run(ops, id)
+	err = s.runner.Run(ops, id, nil)
 	c.Assert(err, IsNil)
 
 	m = nil
@@ -542,7 +542,7 @@ func (s *S) TestChangeLog(c *C) {
 		Remove: true,
 	}}
 	id = bson.NewObjectId()
-	err = s.runner.Run(ops, id)
+	err = s.runner.Run(ops, id, nil)
 	c.Assert(err, IsNil)
 
 	m = nil
@@ -591,7 +591,7 @@ func (s *S) TestInsertStressTest(c *C) {
 							"added-by": i,
 						},
 					}}
-					err := runner.Run(ops, "")
+					err := runner.Run(ops, "", nil)
 					if err != txn.ErrAborted {
 						c.Check(err, IsNil)
 					}

--- a/sstxn/sstxn_test.go
+++ b/sstxn/sstxn_test.go
@@ -549,8 +549,8 @@ func (s *S) TestChangeLog(c *C) {
 	err = chglog.FindId(id).One(&m)
 	c.Assert(err, IsNil)
 
-	c.Assert(m["accounts"], DeepEquals, &Log{IdList{0}, []int64{-1}})
-	c.Assert(m["people"], DeepEquals, &Log{IdList{"joe"}, []int64{-1}})
+	c.Assert(m["accounts"], DeepEquals, &Log{IdList{0}, []int64{-4}})
+	c.Assert(m["people"], DeepEquals, &Log{IdList{"joe"}, []int64{-3}})
 }
 
 func (s *S) TestInsertStressTest(c *C) {


### PR DESCRIPTION
This implements a wrapper around StartTransaction/CommitTransaction/AbortTransaction that conforms to the existing mgo/txn.Runner interface.
It calls StartTransaction, then validates all Asserts, and then Commit/Abort as relevant.
This is done as a drop-in replacement for Runner.Run. Ultimately, I think we want to use a different interface up at the juju/txn interface. There we have a buildTxn syntax, where the client code reads the database and then applies the changes to the database, and ideally all of that would be inside the same transaction.
However, that turns out to require some pretty major reworking of several layers, because of things like MultiModelRunner.

The code is a lot simpler than the existing client-side transactions, since all of the heavy lifting is done server side.
