### PR TITLE
Always use the mutex to protect log functions

### DIFF
--- a/log.go
+++ b/log.go
@@ -55,78 +55,62 @@ var (
 
 // Specify the *log.Logger object where log messages should be sent to.
 func SetLogger(logger log_Logger) {
-	if raceDetector {
-		globalMutex.Lock()
-		defer globalMutex.Unlock()
-	}
+	globalMutex.Lock()
+	defer globalMutex.Unlock()
 	globalLogger = logger
 }
 
 // Enable the delivery of debug messages to the logger.  Only meaningful
 // if a logger is also set.
 func SetDebug(debug bool) {
-	if raceDetector {
-		globalMutex.Lock()
-		defer globalMutex.Unlock()
-	}
+	globalMutex.Lock()
+	defer globalMutex.Unlock()
 	globalDebug = debug
 }
 
 func log(v ...interface{}) {
-	if raceDetector {
-		globalMutex.Lock()
-		defer globalMutex.Unlock()
-	}
+	globalMutex.Lock()
+	defer globalMutex.Unlock()
 	if globalLogger != nil {
 		globalLogger.Output(2, fmt.Sprint(v...))
 	}
 }
 
 func logln(v ...interface{}) {
-	if raceDetector {
-		globalMutex.Lock()
-		defer globalMutex.Unlock()
-	}
+	globalMutex.Lock()
+	defer globalMutex.Unlock()
 	if globalLogger != nil {
 		globalLogger.Output(2, fmt.Sprintln(v...))
 	}
 }
 
 func logf(format string, v ...interface{}) {
-	if raceDetector {
-		globalMutex.Lock()
-		defer globalMutex.Unlock()
-	}
+	globalMutex.Lock()
+	defer globalMutex.Unlock()
 	if globalLogger != nil {
 		globalLogger.Output(2, fmt.Sprintf(format, v...))
 	}
 }
 
 func debug(v ...interface{}) {
-	if raceDetector {
-		globalMutex.Lock()
-		defer globalMutex.Unlock()
-	}
+	globalMutex.Lock()
+	defer globalMutex.Unlock()
 	if globalDebug && globalLogger != nil {
 		globalLogger.Output(2, fmt.Sprint(v...))
 	}
 }
 
 func debugln(v ...interface{}) {
-	if raceDetector {
-		globalMutex.Lock()
-		defer globalMutex.Unlock()
-	}
+	globalMutex.Lock()
+	defer globalMutex.Unlock()
 	if globalDebug && globalLogger != nil {
 		globalLogger.Output(2, fmt.Sprintln(v...))
 	}
 }
 
 func debugf(format string, v ...interface{}) {
-	if raceDetector {
-		globalMutex.Lock()
-		defer globalMutex.Unlock()
-	}
+	globalMutex.Lock()
+	defer globalMutex.Unlock()
 	if globalDebug && globalLogger != nil {
 		globalLogger.Output(2, fmt.Sprintf(format, v...))
 	}


### PR DESCRIPTION
When used with juju, we have different go routines which update the logging config and which run the mgo functions. So we need to protect the logging methods with the mutex, not just when the "race" flag is set.