### PR TITLE
Retry server side txns when a write conflict occurs

### DIFF
--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -69,9 +69,6 @@ func (dbs *DBServer) start() {
 		"--dbpath", dbs.dbpath,
 		"--bind_ip", "127.0.0.1",
 		"--port", strconv.Itoa(addr.Port),
-		"--nssize", "1",
-		"--noprealloc",
-		"--smallfiles",
 	}
 	if dbs.replset != "" {
 		args = append(args, fmt.Sprintf("--replSet=%s", dbs.replset))

--- a/dbtest/dbserver_test.go
+++ b/dbtest/dbserver_test.go
@@ -49,7 +49,7 @@ func (s *S) TestWipeData(c *C) {
 	session.Close()
 	c.Assert(err, IsNil)
 	for _, name := range names {
-		if name != "local" && name != "admin" {
+		if name != "local" && name != "admin" && name != "config" {
 			c.Fatalf("Wipe should have removed this database: %s", name)
 		}
 	}

--- a/sstxn/sstxn_test.go
+++ b/sstxn/sstxn_test.go
@@ -500,10 +500,7 @@ func (s *S) TestVerifyFieldOrdering(c *C) {
 func (s *S) TestChangeLog(c *C) {
 	c.Assert(s.db.C("people").Create(&mgo.CollectionInfo{}), IsNil)
 	c.Assert(s.db.C("debts").Create(&mgo.CollectionInfo{}), IsNil)
-	c.Assert(s.db.C("chglog").Create(&mgo.CollectionInfo{
-		Capped:   true,
-		MaxBytes: 1e6,
-	}), IsNil)
+	c.Assert(s.db.C("chglog").Create(&mgo.CollectionInfo{}), IsNil)
 	chglog := s.db.C("chglog")
 	s.runner.ChangeLog(chglog)
 


### PR DESCRIPTION
Sometimes the mongodb server can return a write conflict error (code 112).
The expectation is that the transaction be retried.
This has been observed in Juju where a transaction was completed but an immediate subsequent txn failed to see the previous data. A small delay (or txn retry) is needed.

The PR also removed support for nmap mongo test servers and the test capped log collection so the test suite passes on mongo 4.4.x.