### PR TITLE
Increasing defaultMaxTxnQueueLength to 100000

### DIFF
--- a/txn/txn.go
+++ b/txn/txn.go
@@ -221,7 +221,7 @@ type Runner struct {
 	opts RunnerOptions   // runtime options
 }
 
-const defaultMaxTxnQueueLength = 1000
+const defaultMaxTxnQueueLength = 100000
 const defaultAssertionCleanupLength = 10
 
 // NewRunner returns a new transaction runner that uses tc to hold its


### PR DESCRIPTION
If txn is over 1000, mgopurge stop.

As there is no option to configure this, It would be better
if defaultMaxTxnQueueLength much over 1000