### PR TITLE
Fix readConcern and writeConcern for starting and committing txns.

### DIFF
--- a/session.go
+++ b/session.go
@@ -5120,16 +5120,14 @@ func (s *Session) finishTransaction(command string) error {
 		for i := 0; i < 2; i++ {
 			finalCmd := cmd
 			if command == "commitTransaction" {
-				finalCmd = append(bson.D(nil), cmd...)
-				if i == 0 {
-					// TODO(sstxn): allow setting initial writeConcern
-					finalCmd = append(finalCmd,
-						bson.DocElem{Name: "writeConcern", Value: bson.M{"w": "majority", "wtimeout": 1000}})
-				} else {
-					// Python driver sets wtime to 10000ms and writeConcern to majority after the first attempt.
-					finalCmd = append(finalCmd,
-						bson.DocElem{Name: "writeConcern", Value: bson.M{"w": "majority", "wtimeout": 10000}})
+				// TODO(sstxn): allow setting initial writeConcern
+				wtimeout := 1000
+				if i > 0 {
+					// Python driver sets wtimeout to 10000ms and writeConcern to majority after the first attempt.
+					wtimeout = 10000
 				}
+				finalCmd = append(finalCmd, bson.DocElem{Name: "writeConcern",
+					Value: bson.M{"w": "majority", "wtimeout": wtimeout}})
 			}
 			err = s.Run(finalCmd, nil)
 			if err == nil {

--- a/sstxn/sstxn.go
+++ b/sstxn/sstxn.go
@@ -152,6 +152,8 @@ func (r *Runner) Run(ops []txn.Op, id bson.ObjectId, info interface{}) (err erro
 
 func (r *Runner) runTxn(ops []txn.Op, id bson.ObjectId) error {
 	completed := false
+	// Force readPreference primary
+	r.db.Session.SetMode(mgo.Strong, true)
 	if err := r.db.Session.StartTransaction(); err != nil {
 		return err
 	}


### PR DESCRIPTION
For safety, we need to set the readConcern and writeConcern in transactions and ensure readPreference is on the primary.