### PR TITLE
feat: close unused sockets

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -54,6 +54,7 @@ type mongoSocket struct {
 	gotNonce      sync.Cond
 	dead          error
 	serverInfo    *mongoServerInfo
+	lastUsed      time.Time
 }
 
 type queryOpFlags uint32
@@ -233,6 +234,7 @@ func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, timeout t
 	stats.socketsInUse(+1)
 	stats.socketRefs(+1)
 	socket.Unlock()
+	socket.lastUsed = time.Now()
 	return nil
 }
 
@@ -250,6 +252,7 @@ func (socket *mongoSocket) Acquire() (info *mongoServerInfo) {
 	stats.socketRefs(+1)
 	serverInfo := socket.serverInfo
 	socket.Unlock()
+	socket.lastUsed = time.Now()
 	return serverInfo
 }
 


### PR DESCRIPTION
An experiement to close unused sockets after a period of inactivity. This is a poor mans socket idle timeout. The socket will remain open even after the socket has been released. During times of high usage of a session followed by lull periods, the number of unused sockets can remain very high. This high watermark can exist for in perpetuity of the application, only a close to the server or a restart will clear it. This is problematic, as thousands (millions!) of sockets can remain.

It's not possible to use the pool limit, as load shedding requires a lot of change to juju itself.

An alternative strategy for the pool limit, would be to close the socket if the number of live sockets and unused sockets are over a given number. The cost of creating those new sockets will become larger, but when the lull period occurs, the number of sockets will fall to a low watermark.