### PR TITLE
chore: shell out to getent to get user home directory

### DIFF
--- a/testing/mgo.go
+++ b/testing/mgo.go
@@ -184,11 +184,29 @@ func generatePEM(path string, serverCert *x509.Certificate, serverKey *rsa.Priva
 
 // getHome for robust detection of HOME directory for use on Linux with
 // snaps.
+//
+// Use `getent passwd` to find the home directory of the user
+// falling back to reading /etc/passwd if the command fails.
+// In some environments /etc/passwd may not be available or
+// is not the source of truth (e.g., LDAP, NSS).
+// And don't use os/user package as it requires CGO on Linux.
 func getHome() (string, error) {
 	targetUID := strconv.Itoa(os.Getuid())
-	passwd, err := ioutil.ReadFile("/etc/passwd")
-	if err != nil {
-		return "", errors.Trace(err)
+	var passwd []byte
+	var err error
+
+	cmd := exec.Command("getent", "passwd", targetUID)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	if runErr := cmd.Run(); runErr == nil {
+		passwd = out.Bytes()
+	} else {
+		// Fallback to reading /etc/passwd directly.
+		passwd, err = os.ReadFile("/etc/passwd")
+		if err != nil {
+			return "", errors.Trace(err)
+		}
 	}
 	lines := strings.Split(string(passwd), "\n")
 	for _, line := range lines {


### PR DESCRIPTION
I encountered the following error when running a Juju test that uses the Mongo suite.
`mgo.go:566: failed to find HOME directory: UNIX user 1591302234 not found`

This only occured after switching to a Canonical corporate laptop. I was able to trace the issue down to how we determine the user's home directory in tests that spin up Mongo.

On coporate laptops with authd, the user's account does not exist in /etc/passwd. Instead NSS (Name Server Switch) is used to obtain the user's details. To fix the issue, shell out to `getent passwd <userID>` to get the user's home directory and fallback to reading /etc/passwd in case the command execution fails.

Some semi-related docs that helped explain the issue can be found [here](https://www.gnu.org/software/libc/manual/html_node/Name-Service-Switch.html) and [here](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/configuring_authentication_and_authorization_in_rhel/understanding-sssd-and-its-benefits_configuring-authentication-and-authorization-in-rhel).